### PR TITLE
feat: 카테고리 crud, 상품 crud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,34 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// querydsl
+	implementation 'io.github.openfeign.querydsl:querydsl-jpa:6.10.1'
+	implementation 'io.github.openfeign.querydsl:querydsl-core:6.10.1'
+
+	annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:6.10.1:jpa'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+}
+
+def generatedQuerydslDir = layout.buildDirectory.dir("generated/sources/annotationProcessor/java/main").get().asFile
+
+sourceSets {
+	main {
+		java {
+			srcDirs += generatedQuerydslDir
+		}
+	}
+}
+
+tasks.withType(JavaCompile).configureEach {
+	options.compilerArgs += ["-Aquerydsl.generatedAnnotationProcessor=QUERYDSL", "-s", generatedQuerydslDir.toString()]
+}
+
+tasks.named('clean') {
+	doFirst {
+		delete generatedQuerydslDir
+	}
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,14 @@ dependencies {
 	annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:6.10.1:jpa'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+
+	// s3
+	implementation platform('software.amazon.awssdk:bom:2.27.21')
+	implementation 'software.amazon.awssdk:s3'
+	testImplementation 'io.findify:s3mock_2.12:0.2.6'
+
+	// env
+	implementation 'io.github.cdimascio:java-dotenv:5.2.2'
 }
 
 def generatedQuerydslDir = layout.buildDirectory.dir("generated/sources/annotationProcessor/java/main").get().asFile

--- a/src/main/java/org/orderhub/pr/category/domain/Category.java
+++ b/src/main/java/org/orderhub/pr/category/domain/Category.java
@@ -33,7 +33,8 @@ public class Category {
     private LocalDateTime updatedAt;
 
     @Builder
-    public Category(String name, Category parent, CategoryType type) {
+    public Category(Long id, String name, Category parent, CategoryType type) {
+        this.id = id;
         this.name = name;
         this.parent = parent;
         this.type = type;

--- a/src/main/java/org/orderhub/pr/category/domain/Category.java
+++ b/src/main/java/org/orderhub/pr/category/domain/Category.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.orderhub.pr.category.dto.request.CategoryUpdateRequest;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -38,8 +39,8 @@ public class Category {
 
     private CategoryStatus status;
 
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+    private Instant createdAt;
+    private Instant updatedAt;
 
     @Builder
     public Category(Long id, String name, Category parent, CategoryType type) {
@@ -51,14 +52,14 @@ public class Category {
 
     @PrePersist
     protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
+        this.createdAt = Instant.now();
+        this.updatedAt = Instant.now();
         this.status = CategoryStatus.ACTIVE;
     }
 
     @PreUpdate
     protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
+        this.updatedAt = Instant.now();
     }
 
     public void delete() {

--- a/src/main/java/org/orderhub/pr/category/domain/Category.java
+++ b/src/main/java/org/orderhub/pr/category/domain/Category.java
@@ -5,8 +5,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.orderhub.pr.category.dto.request.CategoryUpdateRequest;
 
 import java.time.LocalDateTime;
+
+import static org.orderhub.pr.category.exception.ExceptionMessage.CANNOT_BE_YOUR_OWN_PARENT;
 
 @Entity
 @Getter
@@ -51,5 +54,13 @@ public class Category {
         this.updatedAt = LocalDateTime.now();
     }
 
+    public void applyUpdate(String newName, CategoryType newType, Category newParent) {
+        if (newParent != null && newParent.equals(this)) {
+            throw new IllegalArgumentException(CANNOT_BE_YOUR_OWN_PARENT);
+        }
+        this.name = newName;
+        this.parent = newParent;
+        this.type = newType;
+    }
 
 }

--- a/src/main/java/org/orderhub/pr/category/domain/Category.java
+++ b/src/main/java/org/orderhub/pr/category/domain/Category.java
@@ -9,8 +9,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.orderhub.pr.category.exception.ExceptionMessage.CANNOT_BE_YOUR_OWN_CHILD;
-import static org.orderhub.pr.category.exception.ExceptionMessage.CANNOT_BE_YOUR_OWN_PARENT;
+import static org.orderhub.pr.category.exception.ExceptionMessage.*;
 
 @Entity
 @Getter
@@ -78,6 +77,15 @@ public class Category {
         if (newParent != null && newParent.equals(this)) {
             throw new IllegalArgumentException(CANNOT_BE_YOUR_OWN_PARENT);
         }
+
+        if (newType == CategoryType.MAJOR && newParent != null) {
+            throw new IllegalArgumentException(MAJOR_CANNOT_BE_CHILD);
+        }
+
+        if (this.type == CategoryType.MINOR && !this.children.isEmpty()) {
+            throw new IllegalArgumentException(MINOR_CANNOT_BE_PARENT);
+        }
+
         this.name = newName;
         this.parent = newParent;
         this.type = newType;
@@ -86,6 +94,9 @@ public class Category {
     public void addChild(Category child) {
         if (child.equals(this)) {
             throw new IllegalArgumentException(CANNOT_BE_YOUR_OWN_CHILD);
+        }
+        if (this.type == CategoryType.MINOR) {
+            throw new IllegalArgumentException(MINOR_CANNOT_BE_PARENT);
         }
         this.children.add(child);
         child.setParent(this);

--- a/src/main/java/org/orderhub/pr/category/domain/Category.java
+++ b/src/main/java/org/orderhub/pr/category/domain/Category.java
@@ -2,6 +2,7 @@ package org.orderhub.pr.category.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -30,6 +31,13 @@ public class Category {
 
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    @Builder
+    public Category(String name, Category parent, CategoryType type) {
+        this.name = name;
+        this.parent = parent;
+        this.type = type;
+    }
 
     @PrePersist
     protected void onCreate() {

--- a/src/main/java/org/orderhub/pr/category/domain/Category.java
+++ b/src/main/java/org/orderhub/pr/category/domain/Category.java
@@ -1,13 +1,11 @@
 package org.orderhub.pr.category.domain;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.orderhub.pr.category.dto.request.CategoryUpdateRequest;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.orderhub.pr.category.exception.ExceptionMessage.CANNOT_BE_YOUR_OWN_PARENT;
@@ -25,12 +23,13 @@ public class Category {
     @Column(nullable = false)
     private String name;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
     private Category parent;
 
-    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Category> children;
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<Category> children = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -80,6 +79,11 @@ public class Category {
         this.name = newName;
         this.parent = newParent;
         this.type = newType;
+    }
+
+    public void addChild(Category child) {
+        this.children.add(child);
+        child.setParent(this);
     }
 
 }

--- a/src/main/java/org/orderhub/pr/category/domain/Category.java
+++ b/src/main/java/org/orderhub/pr/category/domain/Category.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.orderhub.pr.category.exception.ExceptionMessage.CANNOT_BE_YOUR_OWN_CHILD;
 import static org.orderhub.pr.category.exception.ExceptionMessage.CANNOT_BE_YOUR_OWN_PARENT;
 
 @Entity
@@ -82,6 +83,9 @@ public class Category {
     }
 
     public void addChild(Category child) {
+        if (child.equals(this)) {
+            throw new IllegalArgumentException(CANNOT_BE_YOUR_OWN_CHILD);
+        }
         this.children.add(child);
         child.setParent(this);
     }

--- a/src/main/java/org/orderhub/pr/category/domain/Category.java
+++ b/src/main/java/org/orderhub/pr/category/domain/Category.java
@@ -32,6 +32,8 @@ public class Category {
     @Column(nullable = false)
     private CategoryType type;
 
+    private CategoryStatus status;
+
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -47,11 +49,24 @@ public class Category {
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
+        this.status = CategoryStatus.ACTIVE;
     }
 
     @PreUpdate
     protected void onUpdate() {
         this.updatedAt = LocalDateTime.now();
+    }
+
+    public void delete() {
+        this.status = CategoryStatus.DELETED;
+    }
+
+    public void restore() {
+        this.status = CategoryStatus.ACTIVE;
+    }
+
+    public boolean isActive() {
+        return this.status == CategoryStatus.ACTIVE;
     }
 
     public void applyUpdate(String newName, CategoryType newType, Category newParent) {

--- a/src/main/java/org/orderhub/pr/category/domain/Category.java
+++ b/src/main/java/org/orderhub/pr/category/domain/Category.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import org.orderhub.pr.category.dto.request.CategoryUpdateRequest;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.orderhub.pr.category.exception.ExceptionMessage.CANNOT_BE_YOUR_OWN_PARENT;
 
@@ -27,6 +28,9 @@ public class Category {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
     private Category parent;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Category> children;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/org/orderhub/pr/category/domain/CategoryStatus.java
+++ b/src/main/java/org/orderhub/pr/category/domain/CategoryStatus.java
@@ -1,0 +1,7 @@
+package org.orderhub.pr.category.domain;
+
+public enum CategoryStatus {
+    ACTIVE,
+    INACTIVE,
+    DELETED
+}

--- a/src/main/java/org/orderhub/pr/category/domain/CategoryType.java
+++ b/src/main/java/org/orderhub/pr/category/domain/CategoryType.java
@@ -3,5 +3,13 @@ package org.orderhub.pr.category.domain;
 public enum CategoryType {
     MAJOR, // 대분류
     MIDDLE, // 중분류
-    MINOR // 소분류
+    MINOR; // 소분류
+
+    public static CategoryType fromString(String string) {
+        if (string == null) {
+            return null;
+        }
+        return CategoryType.valueOf(string.toUpperCase());
+    }
+
 }

--- a/src/main/java/org/orderhub/pr/category/dto/CategoryRegisterRequest.java
+++ b/src/main/java/org/orderhub/pr/category/dto/CategoryRegisterRequest.java
@@ -1,0 +1,18 @@
+package org.orderhub.pr.category.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CategoryRegisterRequest {
+
+    private String name;
+    private Long parentCategoryId;
+    private String categoryType;
+
+}

--- a/src/main/java/org/orderhub/pr/category/dto/CategoryRegisterResponse.java
+++ b/src/main/java/org/orderhub/pr/category/dto/CategoryRegisterResponse.java
@@ -1,0 +1,29 @@
+package org.orderhub.pr.category.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.orderhub.pr.category.domain.Category;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CategoryRegisterResponse {
+
+    private Long id;
+    private Long parentId;
+    private String name;
+    private String categoryType;
+
+    public static CategoryRegisterResponse of(Category category) {
+        return CategoryRegisterResponse.builder()
+                .id(category.getId())
+                .name(category.getName())
+                .parentId(category.getParent() == null ? null : category.getParent().getId())
+                .categoryType(category.getType().name())
+                .build();
+    }
+
+}

--- a/src/main/java/org/orderhub/pr/category/dto/request/CategoryRegisterRequest.java
+++ b/src/main/java/org/orderhub/pr/category/dto/request/CategoryRegisterRequest.java
@@ -1,4 +1,4 @@
-package org.orderhub.pr.category.dto;
+package org.orderhub.pr.category.dto.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/org/orderhub/pr/category/dto/request/CategoryUpdateRequest.java
+++ b/src/main/java/org/orderhub/pr/category/dto/request/CategoryUpdateRequest.java
@@ -1,0 +1,19 @@
+package org.orderhub.pr.category.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CategoryUpdateRequest {
+
+    private Long id;
+    private String name;
+    private Long parentCategoryId;
+    private String categoryType;
+
+}

--- a/src/main/java/org/orderhub/pr/category/dto/response/CategoryRegisterResponse.java
+++ b/src/main/java/org/orderhub/pr/category/dto/response/CategoryRegisterResponse.java
@@ -1,4 +1,4 @@
-package org.orderhub.pr.category.dto;
+package org.orderhub.pr.category.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/org/orderhub/pr/category/dto/response/CategoryTreeResponse.java
+++ b/src/main/java/org/orderhub/pr/category/dto/response/CategoryTreeResponse.java
@@ -1,0 +1,31 @@
+package org.orderhub.pr.category.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.orderhub.pr.category.domain.Category;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CategoryTreeResponse {
+
+    private Long id;
+    private String name;
+    private String categoryType;
+    private List<CategoryTreeResponse> children;
+
+    public CategoryTreeResponse(Category category) {
+        this.id = category.getId();
+        this.name = category.getName();
+        this.categoryType = category.getType().name();
+        this.children = category.getChildren().stream().map(CategoryTreeResponse::new).collect(Collectors.toList());
+    }
+
+
+}

--- a/src/main/java/org/orderhub/pr/category/dto/response/CategoryUpdateResponse.java
+++ b/src/main/java/org/orderhub/pr/category/dto/response/CategoryUpdateResponse.java
@@ -1,0 +1,27 @@
+package org.orderhub.pr.category.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.orderhub.pr.category.domain.Category;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CategoryUpdateResponse {
+    private Long id;
+    private Long parentId;
+    private String name;
+    private String categoryType;
+
+    public static CategoryUpdateResponse of(Category category) {
+        return CategoryUpdateResponse.builder()
+                .id(category.getId())
+                .name(category.getName())
+                .parentId(category.getParent() == null ? null : category.getParent().getId())
+                .categoryType(category.getType().name())
+                .build();
+    }
+}

--- a/src/main/java/org/orderhub/pr/category/exception/ExceptionMessage.java
+++ b/src/main/java/org/orderhub/pr/category/exception/ExceptionMessage.java
@@ -1,0 +1,12 @@
+package org.orderhub.pr.category.exception;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ExceptionMessage {
+
+    public static final String NO_SUCH_CATEGORY = "해당하는 카테고리를 찾을 수 없습니다.";
+    public static final String NO_SUCH_PARENT_CATEGORY = "요청하신 부모 카테고리를 찾을 수 없습니다.";
+
+}

--- a/src/main/java/org/orderhub/pr/category/exception/ExceptionMessage.java
+++ b/src/main/java/org/orderhub/pr/category/exception/ExceptionMessage.java
@@ -9,5 +9,6 @@ public class ExceptionMessage {
     public static final String NO_SUCH_CATEGORY = "해당하는 카테고리를 찾을 수 없습니다.";
     public static final String NO_SUCH_PARENT_CATEGORY = "요청하신 부모 카테고리를 찾을 수 없습니다.";
     public static final String CANNOT_BE_YOUR_OWN_PARENT = "부모 카테고리는 자기 자신일 수 없습니다.";
+    public static final String CANNOT_BE_YOUR_OWN_CHILD = "자기 자신을 자식 카테고리로 추가할 수 없습니다.";
 
 }

--- a/src/main/java/org/orderhub/pr/category/exception/ExceptionMessage.java
+++ b/src/main/java/org/orderhub/pr/category/exception/ExceptionMessage.java
@@ -11,4 +11,6 @@ public class ExceptionMessage {
     public static final String CANNOT_BE_YOUR_OWN_PARENT = "부모 카테고리는 자기 자신일 수 없습니다.";
     public static final String CANNOT_BE_YOUR_OWN_CHILD = "자기 자신을 자식 카테고리로 추가할 수 없습니다.";
 
+    public static final String MAJOR_CANNOT_BE_CHILD = "대분류는 자식 카테고리로 추가할 수 없습니다.";
+    public static final String MINOR_CANNOT_BE_PARENT = "소분류는 부모 카테고리로 추가할 수 없습니다.";
 }

--- a/src/main/java/org/orderhub/pr/category/exception/ExceptionMessage.java
+++ b/src/main/java/org/orderhub/pr/category/exception/ExceptionMessage.java
@@ -8,5 +8,6 @@ public class ExceptionMessage {
 
     public static final String NO_SUCH_CATEGORY = "해당하는 카테고리를 찾을 수 없습니다.";
     public static final String NO_SUCH_PARENT_CATEGORY = "요청하신 부모 카테고리를 찾을 수 없습니다.";
+    public static final String CANNOT_BE_YOUR_OWN_PARENT = "부모 카테고리는 자기 자신일 수 없습니다.";
 
 }

--- a/src/main/java/org/orderhub/pr/category/repository/CategoryRepository.java
+++ b/src/main/java/org/orderhub/pr/category/repository/CategoryRepository.java
@@ -3,10 +3,18 @@ package org.orderhub.pr.category.repository;
 import org.orderhub.pr.category.domain.Category;
 import org.orderhub.pr.category.domain.CategoryStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
     List<Category> findByParentIsNull();
     List<Category> findByParentIsNullAndStatus(CategoryStatus status);
+
+    @Query("SELECT c FROM Category c LEFT JOIN FETCH c.children WHERE c.parent IS NULL")
+    List<Category> findAllWithChildren();
+
+    @Query("SELECT DISTINCT c FROM Category c LEFT JOIN FETCH c.children WHERE c.parent IS NULL AND c.status = :status")
+    List<Category> findWithChildrenAndStatus(@Param("status") CategoryStatus status);
 }

--- a/src/main/java/org/orderhub/pr/category/repository/CategoryRepository.java
+++ b/src/main/java/org/orderhub/pr/category/repository/CategoryRepository.java
@@ -1,7 +1,12 @@
 package org.orderhub.pr.category.repository;
 
 import org.orderhub.pr.category.domain.Category;
+import org.orderhub.pr.category.domain.CategoryStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+    List<Category> findByParentIsNull();
+    List<Category> findByParentIsNullAndStatus(CategoryStatus status);
 }

--- a/src/main/java/org/orderhub/pr/category/repository/CategoryRepository.java
+++ b/src/main/java/org/orderhub/pr/category/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package org.orderhub.pr.category.repository;
+
+import org.orderhub.pr.category.domain.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/org/orderhub/pr/category/service/CategoryService.java
+++ b/src/main/java/org/orderhub/pr/category/service/CategoryService.java
@@ -1,7 +1,7 @@
 package org.orderhub.pr.category.service;
 
-import org.orderhub.pr.category.dto.CategoryRegisterRequest;
-import org.orderhub.pr.category.dto.CategoryRegisterResponse;
+import org.orderhub.pr.category.dto.request.CategoryRegisterRequest;
+import org.orderhub.pr.category.dto.response.CategoryRegisterResponse;
 
 public interface CategoryService {
 

--- a/src/main/java/org/orderhub/pr/category/service/CategoryService.java
+++ b/src/main/java/org/orderhub/pr/category/service/CategoryService.java
@@ -1,0 +1,10 @@
+package org.orderhub.pr.category.service;
+
+import org.orderhub.pr.category.dto.CategoryRegisterRequest;
+import org.orderhub.pr.category.dto.CategoryRegisterResponse;
+
+public interface CategoryService {
+
+    public CategoryRegisterResponse categoryRegister(CategoryRegisterRequest request);
+
+}

--- a/src/main/java/org/orderhub/pr/category/service/CategoryService.java
+++ b/src/main/java/org/orderhub/pr/category/service/CategoryService.java
@@ -1,5 +1,6 @@
 package org.orderhub.pr.category.service;
 
+import org.orderhub.pr.category.domain.Category;
 import org.orderhub.pr.category.dto.request.CategoryRegisterRequest;
 import org.orderhub.pr.category.dto.request.CategoryUpdateRequest;
 import org.orderhub.pr.category.dto.response.CategoryRegisterResponse;
@@ -11,5 +12,6 @@ public interface CategoryService {
     public CategoryUpdateResponse categoryUpdate(CategoryUpdateRequest request);
     public void categoryDelete(Long id);
     public void categoryRestore(Long id);
+    public Category findById(Long id);
 
 }

--- a/src/main/java/org/orderhub/pr/category/service/CategoryService.java
+++ b/src/main/java/org/orderhub/pr/category/service/CategoryService.java
@@ -1,10 +1,15 @@
 package org.orderhub.pr.category.service;
 
 import org.orderhub.pr.category.dto.request.CategoryRegisterRequest;
+import org.orderhub.pr.category.dto.request.CategoryUpdateRequest;
 import org.orderhub.pr.category.dto.response.CategoryRegisterResponse;
+import org.orderhub.pr.category.dto.response.CategoryUpdateResponse;
 
 public interface CategoryService {
 
     public CategoryRegisterResponse categoryRegister(CategoryRegisterRequest request);
+    public CategoryUpdateResponse categoryUpdate(CategoryUpdateRequest request);
+    public void categoryDelete(Long id);
+    public void categoryRestore(Long id);
 
 }

--- a/src/main/java/org/orderhub/pr/category/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/org/orderhub/pr/category/service/impl/CategoryServiceImpl.java
@@ -57,4 +57,15 @@ public class CategoryServiceImpl implements CategoryService {
         return CategoryUpdateResponse.of(currentCategory);
     }
 
+    @Transactional
+    public void categoryDelete(Long id) {
+        Category category = findById(id);
+        category.delete();
+    }
+
+    @Transactional
+    public void categoryRestore(Long id) {
+        Category category = findById(id);
+        category.restore();
+    }
 }

--- a/src/main/java/org/orderhub/pr/category/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/org/orderhub/pr/category/service/impl/CategoryServiceImpl.java
@@ -1,0 +1,41 @@
+package org.orderhub.pr.category.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.orderhub.pr.category.domain.Category;
+import org.orderhub.pr.category.domain.CategoryType;
+import org.orderhub.pr.category.dto.CategoryRegisterRequest;
+import org.orderhub.pr.category.dto.CategoryRegisterResponse;
+import org.orderhub.pr.category.exception.ExceptionMessage;
+import org.orderhub.pr.category.repository.CategoryRepository;
+import org.orderhub.pr.category.service.CategoryService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CategoryServiceImpl implements CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    @Transactional
+    public CategoryRegisterResponse categoryRegister(CategoryRegisterRequest request) {
+        Category category = Category.builder()
+                .name(request.getName())
+                .parent(request.getParentCategoryId() == null ? null : findById(request.getParentCategoryId()))
+                .type(CategoryType.fromString(request.getCategoryType()))
+                .build();
+
+        Category savedCategory = categoryRepository.save(category);
+
+        return CategoryRegisterResponse.of(savedCategory);
+    }
+
+    private Category findById(Long id) {
+        return categoryRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException(ExceptionMessage.NO_SUCH_CATEGORY));
+    }
+
+}

--- a/src/main/java/org/orderhub/pr/category/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/org/orderhub/pr/category/service/impl/CategoryServiceImpl.java
@@ -3,8 +3,8 @@ package org.orderhub.pr.category.service.impl;
 import lombok.RequiredArgsConstructor;
 import org.orderhub.pr.category.domain.Category;
 import org.orderhub.pr.category.domain.CategoryType;
-import org.orderhub.pr.category.dto.CategoryRegisterRequest;
-import org.orderhub.pr.category.dto.CategoryRegisterResponse;
+import org.orderhub.pr.category.dto.request.CategoryRegisterRequest;
+import org.orderhub.pr.category.dto.response.CategoryRegisterResponse;
 import org.orderhub.pr.category.exception.ExceptionMessage;
 import org.orderhub.pr.category.repository.CategoryRepository;
 import org.orderhub.pr.category.service.CategoryService;
@@ -37,5 +37,7 @@ public class CategoryServiceImpl implements CategoryService {
         return categoryRepository.findById(id)
                 .orElseThrow(() -> new NoSuchElementException(ExceptionMessage.NO_SUCH_CATEGORY));
     }
+
+
 
 }

--- a/src/main/java/org/orderhub/pr/category/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/org/orderhub/pr/category/service/impl/CategoryServiceImpl.java
@@ -27,14 +27,14 @@ public class CategoryServiceImpl implements CategoryService {
     private final CategoryRepository categoryRepository;
 
     public List<CategoryTreeResponse> getAllCategories() {
-        List<Category> rootCategories = categoryRepository.findByParentIsNull();
+        List<Category> rootCategories = categoryRepository.findAllWithChildren();
         return rootCategories.stream()
                 .map(CategoryTreeResponse::new)
                 .collect(Collectors.toList());
     }
 
     public List<CategoryTreeResponse> getAllCategoriesByActive() {
-        List<Category> rootCategories = categoryRepository.findByParentIsNullAndStatus(CategoryStatus.ACTIVE);
+        List<Category> rootCategories = categoryRepository.findWithChildrenAndStatus(CategoryStatus.ACTIVE);
         return rootCategories.stream()
                 .map(CategoryTreeResponse::new)
                 .collect(Collectors.toList());

--- a/src/main/java/org/orderhub/pr/category/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/org/orderhub/pr/category/service/impl/CategoryServiceImpl.java
@@ -4,7 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.orderhub.pr.category.domain.Category;
 import org.orderhub.pr.category.domain.CategoryType;
 import org.orderhub.pr.category.dto.request.CategoryRegisterRequest;
+import org.orderhub.pr.category.dto.request.CategoryUpdateRequest;
 import org.orderhub.pr.category.dto.response.CategoryRegisterResponse;
+import org.orderhub.pr.category.dto.response.CategoryUpdateResponse;
 import org.orderhub.pr.category.exception.ExceptionMessage;
 import org.orderhub.pr.category.repository.CategoryRepository;
 import org.orderhub.pr.category.service.CategoryService;
@@ -38,6 +40,21 @@ public class CategoryServiceImpl implements CategoryService {
                 .orElseThrow(() -> new NoSuchElementException(ExceptionMessage.NO_SUCH_CATEGORY));
     }
 
+    @Transactional
+    public CategoryUpdateResponse categoryUpdate(CategoryUpdateRequest request) {
+        Category currentCategory = findById(request.getId());
 
+        Category parentCategory = (request.getParentCategoryId() != null)
+                ? findById(request.getParentCategoryId())
+                : null;
+
+        currentCategory.applyUpdate(
+                request.getName(),
+                CategoryType.fromString(request.getCategoryType()),
+                parentCategory
+        );
+
+        return CategoryUpdateResponse.of(currentCategory);
+    }
 
 }

--- a/src/main/java/org/orderhub/pr/category/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/org/orderhub/pr/category/service/impl/CategoryServiceImpl.java
@@ -2,10 +2,12 @@ package org.orderhub.pr.category.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import org.orderhub.pr.category.domain.Category;
+import org.orderhub.pr.category.domain.CategoryStatus;
 import org.orderhub.pr.category.domain.CategoryType;
 import org.orderhub.pr.category.dto.request.CategoryRegisterRequest;
 import org.orderhub.pr.category.dto.request.CategoryUpdateRequest;
 import org.orderhub.pr.category.dto.response.CategoryRegisterResponse;
+import org.orderhub.pr.category.dto.response.CategoryTreeResponse;
 import org.orderhub.pr.category.dto.response.CategoryUpdateResponse;
 import org.orderhub.pr.category.exception.ExceptionMessage;
 import org.orderhub.pr.category.repository.CategoryRepository;
@@ -13,7 +15,9 @@ import org.orderhub.pr.category.service.CategoryService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -21,6 +25,20 @@ import java.util.NoSuchElementException;
 public class CategoryServiceImpl implements CategoryService {
 
     private final CategoryRepository categoryRepository;
+
+    public List<CategoryTreeResponse> getAllCategories() {
+        List<Category> rootCategories = categoryRepository.findByParentIsNull();
+        return rootCategories.stream()
+                .map(CategoryTreeResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    public List<CategoryTreeResponse> getAllCategoriesByActive() {
+        List<Category> rootCategories = categoryRepository.findByParentIsNullAndStatus(CategoryStatus.ACTIVE);
+        return rootCategories.stream()
+                .map(CategoryTreeResponse::new)
+                .collect(Collectors.toList());
+    }
 
     @Transactional
     public CategoryRegisterResponse categoryRegister(CategoryRegisterRequest request) {

--- a/src/main/java/org/orderhub/pr/category/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/org/orderhub/pr/category/service/impl/CategoryServiceImpl.java
@@ -53,7 +53,7 @@ public class CategoryServiceImpl implements CategoryService {
         return CategoryRegisterResponse.of(savedCategory);
     }
 
-    private Category findById(Long id) {
+    public Category findById(Long id) {
         return categoryRepository.findById(id)
                 .orElseThrow(() -> new NoSuchElementException(ExceptionMessage.NO_SUCH_CATEGORY));
     }

--- a/src/main/java/org/orderhub/pr/product/aop/ImageValidationAspect.java
+++ b/src/main/java/org/orderhub/pr/product/aop/ImageValidationAspect.java
@@ -1,0 +1,64 @@
+package org.orderhub.pr.product.aop;
+
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.orderhub.pr.product.exception.ExceptionMessage.*;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class ImageValidationAspect {
+
+    @Value("${aws.s3.max-file-size}")
+    private long maxFileSize;
+
+    @Value("${aws.s3.supported-extensions}")
+    private String supportedExtensions;
+
+    @Around("@annotation(org.orderhub.pr.product.aop.annotation.ValidateImage)")
+    public Object validateImageSize(ProceedingJoinPoint joinPoint) throws Throwable {
+        Object[] args = joinPoint.getArgs();
+
+        Set<String> validExtensions = Arrays.stream(supportedExtensions.split(","))
+                .map(String::trim)
+                .collect(Collectors.toSet());
+
+        Arrays.stream(args).forEach(arg -> {
+            if (arg instanceof MultipartFile file) {
+                validateFileSize(file);
+                validateFileExtension(file, validExtensions);
+            }
+        });
+        return joinPoint.proceed(args);
+    }
+
+    private void validateFileSize(MultipartFile file) {
+        if (file.getSize() > maxFileSize) {
+            throw new IllegalArgumentException(FILE_SIZE_EXCEEDED);
+        }
+    }
+
+    private void validateFileExtension(MultipartFile file, Set<String> validExtensions) {
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || !originalFilename.contains(".")) {
+            throw new IllegalArgumentException(INVALID_FILE_FORMAT);
+        }
+
+        String fileExtension = originalFilename.substring(originalFilename.lastIndexOf(".") + 1).toLowerCase();
+
+        if (!validExtensions.contains(fileExtension)) {
+            throw new IllegalArgumentException(UNSUPPORTED_FILE_EXTENSIONS);
+        }
+    }
+
+}

--- a/src/main/java/org/orderhub/pr/product/aop/annotation/ValidateImage.java
+++ b/src/main/java/org/orderhub/pr/product/aop/annotation/ValidateImage.java
@@ -1,0 +1,9 @@
+package org.orderhub.pr.product.aop.annotation;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ValidateImage {
+}

--- a/src/main/java/org/orderhub/pr/product/domain/Product.java
+++ b/src/main/java/org/orderhub/pr/product/domain/Product.java
@@ -69,12 +69,13 @@ public class Product {
 
     public Category getMajorCategory() {
         if (category == null) return null;
-        return category.getParent() != null ? category.getParent().getParent() : category.getParent();
+        Category parent = category.getParent();
+        return (parent != null && parent.getParent() != null) ? parent.getParent() : null;
     }
 
     public Category getMiddleCategory() {
         if (category == null) return null;
-        return category.getParent() == null ? category : category.getParent();
+        return category.getParent();
     }
 
     public void updateProductImage(ProductImage image) {

--- a/src/main/java/org/orderhub/pr/product/domain/Product.java
+++ b/src/main/java/org/orderhub/pr/product/domain/Product.java
@@ -76,4 +76,8 @@ public class Product {
         return category.getParent() == null ? category : category.getParent();
     }
 
+    public void updateProductImage(ProductImage image) {
+        this.image = image;
+    }
+
 }

--- a/src/main/java/org/orderhub/pr/product/domain/Product.java
+++ b/src/main/java/org/orderhub/pr/product/domain/Product.java
@@ -6,8 +6,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.orderhub.pr.category.domain.Category;
+import org.orderhub.pr.util.HashMapConverter;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Entity
 @Getter
@@ -32,6 +34,10 @@ public class Product {
 
     @Enumerated(EnumType.STRING)
     private ConditionStatus conditionStatus;
+
+    @Column(columnDefinition = "jsonb")
+    @Convert(converter = HashMapConverter.class)
+    private Map<String, Object> attributes;
 
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/src/main/java/org/orderhub/pr/product/domain/Product.java
+++ b/src/main/java/org/orderhub/pr/product/domain/Product.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.orderhub.pr.category.domain.Category;
+import org.orderhub.pr.product.dto.request.ProductUpdateRequest;
 import org.orderhub.pr.util.HashMapConverter;
 
 import java.time.Instant;
@@ -78,6 +79,14 @@ public class Product {
 
     public void updateProductImage(ProductImage image) {
         this.image = image;
+    }
+
+    public void updateProduct(ProductUpdateRequest request, Category updatedCategory) {
+        this.name = request.getName();
+        this.price = request.getPrice();
+        this.category = updatedCategory;
+        this.saleStatus = request.getSaleStatus();
+        this.conditionStatus = request.getConditionStatus();
     }
 
 }

--- a/src/main/java/org/orderhub/pr/product/domain/Product.java
+++ b/src/main/java/org/orderhub/pr/product/domain/Product.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import org.orderhub.pr.category.domain.Category;
 import org.orderhub.pr.util.HashMapConverter;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Map;
 
@@ -39,8 +40,8 @@ public class Product {
     @Convert(converter = HashMapConverter.class)
     private Map<String, Object> attributes;
 
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+    private Instant createdAt;
+    private Instant updatedAt;
 
     @Builder
     public Product(String name, String price, String imageUrl, SaleStatus saleStatus, ConditionStatus conditionStatus, Category category) {
@@ -55,13 +56,13 @@ public class Product {
 
     @PrePersist
     protected void onCreate() {
-        createdAt = LocalDateTime.now();
-        updatedAt = LocalDateTime.now();
+        createdAt = Instant.now();
+        updatedAt = Instant.now();
     }
 
     @PreUpdate
     protected void onUpdate() {
-        updatedAt = LocalDateTime.now();
+        updatedAt = Instant.now();
     }
 
     public Category getMajorCategory() {

--- a/src/main/java/org/orderhub/pr/product/domain/Product.java
+++ b/src/main/java/org/orderhub/pr/product/domain/Product.java
@@ -28,7 +28,8 @@ public class Product {
     @JoinColumn(name = "category_id", nullable = true)
     private Category category;
 
-    private String imageUrl;
+    @Embedded
+    private ProductImage image;
 
     @Enumerated(EnumType.STRING)
     private SaleStatus saleStatus;
@@ -44,10 +45,10 @@ public class Product {
     private Instant updatedAt;
 
     @Builder
-    public Product(String name, String price, String imageUrl, SaleStatus saleStatus, ConditionStatus conditionStatus, Category category) {
+    public Product(String name, String price, ProductImage image, SaleStatus saleStatus, ConditionStatus conditionStatus, Category category) {
         this.name = name;
         this.price = price;
-        this.imageUrl = imageUrl;
+        this.image = image;
         this.saleStatus = saleStatus;
         this.conditionStatus = conditionStatus;
         this.category = category;

--- a/src/main/java/org/orderhub/pr/product/domain/Product.java
+++ b/src/main/java/org/orderhub/pr/product/domain/Product.java
@@ -90,4 +90,8 @@ public class Product {
         this.conditionStatus = request.getConditionStatus();
     }
 
+    public void deleteProduct() {
+        this.saleStatus = SaleStatus.DELETED;
+    }
+
 }

--- a/src/main/java/org/orderhub/pr/product/domain/ProductImage.java
+++ b/src/main/java/org/orderhub/pr/product/domain/ProductImage.java
@@ -1,0 +1,18 @@
+package org.orderhub.pr.product.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+public class ProductImage {
+    private String imageUrl;
+
+    @Builder
+    public ProductImage(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/org/orderhub/pr/product/domain/SaleStatus.java
+++ b/src/main/java/org/orderhub/pr/product/domain/SaleStatus.java
@@ -5,5 +5,6 @@ public enum SaleStatus {
     OUT_OF_STOCK,  // 품절
     DISCONTINUED,  // 단종
     PREORDER,      // 예약 판매
-    BACKORDER      // 재입고 예정
+    BACKORDER,      // 재입고 예정
+    DELETED,        // 삭제
 }

--- a/src/main/java/org/orderhub/pr/product/domain/event/ProductCreatedEvent.java
+++ b/src/main/java/org/orderhub/pr/product/domain/event/ProductCreatedEvent.java
@@ -1,0 +1,17 @@
+package org.orderhub.pr.product.domain.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ProductCreatedEvent {
+
+    private final Long productId;
+    private final MultipartFile multipartFile;
+
+}

--- a/src/main/java/org/orderhub/pr/product/domain/event/ProductCreatedEvent.java
+++ b/src/main/java/org/orderhub/pr/product/domain/event/ProductCreatedEvent.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.orderhub.pr.product.dto.request.ProductImageRegisterRequest;
 import org.springframework.web.multipart.MultipartFile;
 
 @Getter
@@ -11,7 +12,6 @@ import org.springframework.web.multipart.MultipartFile;
 @Builder
 public class ProductCreatedEvent {
 
-    private final Long productId;
-    private final MultipartFile multipartFile;
+    private final ProductImageRegisterRequest imageRequest;
 
 }

--- a/src/main/java/org/orderhub/pr/product/dto/request/ProductImageRegisterRequest.java
+++ b/src/main/java/org/orderhub/pr/product/dto/request/ProductImageRegisterRequest.java
@@ -1,0 +1,16 @@
+package org.orderhub.pr.product.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProductImageRegisterRequest {
+    private Long productId;
+    private MultipartFile image;
+}

--- a/src/main/java/org/orderhub/pr/product/dto/request/ProductImageUpdateRequest.java
+++ b/src/main/java/org/orderhub/pr/product/dto/request/ProductImageUpdateRequest.java
@@ -1,0 +1,16 @@
+package org.orderhub.pr.product.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProductImageUpdateRequest {
+    private Long productId;
+    private MultipartFile image;
+}

--- a/src/main/java/org/orderhub/pr/product/dto/request/ProductRegisterRequest.java
+++ b/src/main/java/org/orderhub/pr/product/dto/request/ProductRegisterRequest.java
@@ -19,6 +19,6 @@ public class ProductRegisterRequest {
     private Long categoryId;
     private SaleStatus saleStatus;
     private ConditionStatus conditionStatus;
-    private Long price;
+    private String price;
     private Map<String, Object> attributes;
 }

--- a/src/main/java/org/orderhub/pr/product/dto/request/ProductRegisterRequest.java
+++ b/src/main/java/org/orderhub/pr/product/dto/request/ProductRegisterRequest.java
@@ -1,0 +1,23 @@
+package org.orderhub.pr.product.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.orderhub.pr.product.domain.ConditionStatus;
+import org.orderhub.pr.product.domain.SaleStatus;
+
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProductRegisterRequest {
+    private String name;
+    private String categoryName;
+    private SaleStatus saleStatus;
+    private ConditionStatus conditionStatus;
+    private Long price;
+    private Map<String, Object> attributes;
+}

--- a/src/main/java/org/orderhub/pr/product/dto/request/ProductRegisterRequest.java
+++ b/src/main/java/org/orderhub/pr/product/dto/request/ProductRegisterRequest.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.orderhub.pr.product.domain.ConditionStatus;
+import org.orderhub.pr.product.domain.Product;
 import org.orderhub.pr.product.domain.SaleStatus;
 
 import java.util.Map;
@@ -15,7 +16,7 @@ import java.util.Map;
 @Builder
 public class ProductRegisterRequest {
     private String name;
-    private String categoryName;
+    private Long categoryId;
     private SaleStatus saleStatus;
     private ConditionStatus conditionStatus;
     private Long price;

--- a/src/main/java/org/orderhub/pr/product/dto/request/ProductSearchRequest.java
+++ b/src/main/java/org/orderhub/pr/product/dto/request/ProductSearchRequest.java
@@ -1,0 +1,24 @@
+package org.orderhub.pr.product.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.orderhub.pr.product.domain.ConditionStatus;
+import org.orderhub.pr.product.domain.SaleStatus;
+
+import java.util.Map;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductSearchRequest {
+    private String name;
+    private String categoryName;
+    private SaleStatus saleStatus;
+    private ConditionStatus conditionStatus;
+    private String priceMin;
+    private String priceMax;
+    private Map<String, Object> attributes;
+}

--- a/src/main/java/org/orderhub/pr/product/dto/request/ProductUpdateRequest.java
+++ b/src/main/java/org/orderhub/pr/product/dto/request/ProductUpdateRequest.java
@@ -4,12 +4,20 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.orderhub.pr.product.domain.ConditionStatus;
+import org.orderhub.pr.product.domain.SaleStatus;
+
+import java.util.Map;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProductUpdateRequest {
-
     private String name;
+    private Long categoryId;
+    private SaleStatus saleStatus;
+    private ConditionStatus conditionStatus;
+    private String price;
+    private Map<String, Object> attributes;
 }

--- a/src/main/java/org/orderhub/pr/product/dto/request/ProductUpdateRequest.java
+++ b/src/main/java/org/orderhub/pr/product/dto/request/ProductUpdateRequest.java
@@ -1,14 +1,15 @@
-package org.orderhub.pr.product.dto;
+package org.orderhub.pr.product.dto.request;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ProductRegisterRequest {
+public class ProductUpdateRequest {
 
     private String name;
-
 }

--- a/src/main/java/org/orderhub/pr/product/dto/response/ProductResponse.java
+++ b/src/main/java/org/orderhub/pr/product/dto/response/ProductResponse.java
@@ -33,7 +33,7 @@ public class ProductResponse {
                 .conditionStatus(product.getConditionStatus())
                 .price(product.getPrice())
                 .attributes(product.getAttributes())
-                .imageUrl(product.getImageUrl())
+                .imageUrl(product.getImage().getImageUrl())
                 .build();
     }
 }

--- a/src/main/java/org/orderhub/pr/product/dto/response/ProductResponse.java
+++ b/src/main/java/org/orderhub/pr/product/dto/response/ProductResponse.java
@@ -1,0 +1,39 @@
+package org.orderhub.pr.product.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.orderhub.pr.product.domain.ConditionStatus;
+import org.orderhub.pr.product.domain.Product;
+import org.orderhub.pr.product.domain.SaleStatus;
+
+import java.util.Map;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductResponse {
+    private Long id;
+    private String name;
+    private String categoryName;
+    private SaleStatus saleStatus;
+    private ConditionStatus conditionStatus;
+    private String price;
+    private Map<String, Object> attributes;
+    private String imageUrl;
+
+    public static ProductResponse from(Product product) {
+        return ProductResponse.builder()
+                .id(product.getId())
+                .name(product.getName())
+                .categoryName(product.getCategory().getName())
+                .saleStatus(product.getSaleStatus())
+                .conditionStatus(product.getConditionStatus())
+                .price(product.getPrice())
+                .attributes(product.getAttributes())
+                .imageUrl(product.getImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/org/orderhub/pr/product/dto/response/ProductResponse.java
+++ b/src/main/java/org/orderhub/pr/product/dto/response/ProductResponse.java
@@ -33,7 +33,7 @@ public class ProductResponse {
                 .conditionStatus(product.getConditionStatus())
                 .price(product.getPrice())
                 .attributes(product.getAttributes())
-                .imageUrl(product.getImage().getImageUrl())
+                .imageUrl(product.getImage() == null ? null : product.getImage().getImageUrl())
                 .build();
     }
 }

--- a/src/main/java/org/orderhub/pr/product/dto/response/ProductResponse.java
+++ b/src/main/java/org/orderhub/pr/product/dto/response/ProductResponse.java
@@ -17,6 +17,7 @@ import java.util.Map;
 public class ProductResponse {
     private Long id;
     private String name;
+    private Long categoryId;
     private String categoryName;
     private SaleStatus saleStatus;
     private ConditionStatus conditionStatus;
@@ -28,6 +29,7 @@ public class ProductResponse {
         return ProductResponse.builder()
                 .id(product.getId())
                 .name(product.getName())
+                .categoryId(product.getCategory().getId())
                 .categoryName(product.getCategory().getName())
                 .saleStatus(product.getSaleStatus())
                 .conditionStatus(product.getConditionStatus())

--- a/src/main/java/org/orderhub/pr/product/exception/ExceptionMessage.java
+++ b/src/main/java/org/orderhub/pr/product/exception/ExceptionMessage.java
@@ -1,0 +1,13 @@
+package org.orderhub.pr.product.exception;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ExceptionMessage {
+    public static final String PRODUCT_NOT_FOUND = "해당 상품을 찾을 수 없습니다.";
+
+    public static final String FILE_SIZE_EXCEEDED = "파일 사이즈가 기준치를 초과하였습니다.";
+    public static final String INVALID_FILE_FORMAT = "잘못된 파일 형식입니다.";
+    public static final String UNSUPPORTED_FILE_EXTENSIONS = "지원하지 않는 파일 확장자입니다.";
+}

--- a/src/main/java/org/orderhub/pr/product/repository/CustomProductRepository.java
+++ b/src/main/java/org/orderhub/pr/product/repository/CustomProductRepository.java
@@ -1,10 +1,14 @@
 package org.orderhub.pr.product.repository;
 
 import org.orderhub.pr.product.domain.Product;
+import org.orderhub.pr.product.dto.request.ProductSearchRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Map;
 
 public interface CustomProductRepository {
     List<Product> findByJsonAttributes(Map<String, Object> attributes);
+    public Page<Product> searchProducts(ProductSearchRequest criteria, Pageable pageable);
 }

--- a/src/main/java/org/orderhub/pr/product/repository/CustomProductRepository.java
+++ b/src/main/java/org/orderhub/pr/product/repository/CustomProductRepository.java
@@ -1,0 +1,10 @@
+package org.orderhub.pr.product.repository;
+
+import org.orderhub.pr.product.domain.Product;
+
+import java.util.List;
+import java.util.Map;
+
+public interface CustomProductRepository {
+    List<Product> findByJsonAttributes(Map<String, Object> attributes);
+}

--- a/src/main/java/org/orderhub/pr/product/repository/ProductRepository.java
+++ b/src/main/java/org/orderhub/pr/product/repository/ProductRepository.java
@@ -1,0 +1,8 @@
+package org.orderhub.pr.product.repository;
+
+import org.orderhub.pr.product.domain.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/src/main/java/org/orderhub/pr/product/repository/impl/CustomProductRepositoryImpl.java
+++ b/src/main/java/org/orderhub/pr/product/repository/impl/CustomProductRepositoryImpl.java
@@ -7,7 +7,11 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.orderhub.pr.product.domain.Product;
 import org.orderhub.pr.product.domain.QProduct;
+import org.orderhub.pr.product.dto.request.ProductSearchRequest;
 import org.orderhub.pr.product.repository.CustomProductRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -34,5 +38,52 @@ public class CustomProductRepositoryImpl implements CustomProductRepository {
                 .where(builder)
                 .fetch();
     }
+
+    public Page<Product> searchProducts(ProductSearchRequest criteria, Pageable pageable) {
+        QProduct product = QProduct.product;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (criteria.getName() != null) {
+            builder.and(product.name.containsIgnoreCase(criteria.getName()));
+        }
+
+        if (criteria.getCategoryName() != null) {
+            builder.and(product.category.name.eq(criteria.getCategoryName()));
+        }
+
+        if (criteria.getSaleStatus() != null) {
+            builder.and(product.saleStatus.eq(criteria.getSaleStatus()));
+        }
+
+        if (criteria.getConditionStatus() != null) {
+            builder.and(product.conditionStatus.eq(criteria.getConditionStatus()));
+        }
+
+        if (criteria.getPriceMin() != null && criteria.getPriceMax() != null) {
+            builder.and(product.price.between(criteria.getPriceMin(), criteria.getPriceMax()));
+        }
+
+        if (criteria.getAttributes() != null) {
+            for (Map.Entry<String, Object> entry : criteria.getAttributes().entrySet()) {
+                String jsonCondition = "{\"" + entry.getKey() + "\": \"" + entry.getValue() + "\"}";
+                BooleanExpression condition = Expressions.booleanTemplate("attributes @> {0}", jsonCondition);
+                builder.and(condition);
+            }
+        }
+
+        List<Product> products = queryFactory.selectFrom(product)
+                .where(builder)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory.select(product.count())
+                .from(product)
+                .where(builder)
+                .fetchOne();
+
+        return new PageImpl<>(products, pageable, total != null ? total : 0);
+    }
+
 
 }

--- a/src/main/java/org/orderhub/pr/product/repository/impl/CustomProductRepositoryImpl.java
+++ b/src/main/java/org/orderhub/pr/product/repository/impl/CustomProductRepositoryImpl.java
@@ -1,0 +1,38 @@
+package org.orderhub.pr.product.repository.impl;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.orderhub.pr.product.domain.Product;
+import org.orderhub.pr.product.domain.QProduct;
+import org.orderhub.pr.product.repository.CustomProductRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Map;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomProductRepositoryImpl implements CustomProductRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Product> findByJsonAttributes(Map<String, Object> attributes) {
+        QProduct product = QProduct.product;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        for (Map.Entry<String, Object> entry : attributes.entrySet()) {
+            String jsonCondition = "{\"" + entry.getKey() + "\": \"" + entry.getValue() + "\"}";
+            BooleanExpression condition = Expressions.booleanTemplate("attributes @> {0}", jsonCondition);
+            builder.and(condition);
+        }
+
+        return queryFactory.selectFrom(product)
+                .where(builder)
+                .fetch();
+    }
+
+}

--- a/src/main/java/org/orderhub/pr/product/service/ProductImageService.java
+++ b/src/main/java/org/orderhub/pr/product/service/ProductImageService.java
@@ -1,9 +1,11 @@
 package org.orderhub.pr.product.service;
 
 import org.orderhub.pr.product.dto.request.ProductImageRegisterRequest;
+import org.orderhub.pr.product.dto.request.ProductImageUpdateRequest;
 
 import java.io.IOException;
 
 public interface ProductImageService {
     void processProductImage(ProductImageRegisterRequest request) throws IOException;
+    void updateProductImage(ProductImageUpdateRequest request) throws IOException;
 }

--- a/src/main/java/org/orderhub/pr/product/service/ProductImageService.java
+++ b/src/main/java/org/orderhub/pr/product/service/ProductImageService.java
@@ -1,4 +1,9 @@
 package org.orderhub.pr.product.service;
 
+import org.orderhub.pr.product.dto.request.ProductImageRegisterRequest;
+
+import java.io.IOException;
+
 public interface ProductImageService {
+    void processProductImage(ProductImageRegisterRequest request) throws IOException;
 }

--- a/src/main/java/org/orderhub/pr/product/service/ProductImageService.java
+++ b/src/main/java/org/orderhub/pr/product/service/ProductImageService.java
@@ -1,0 +1,4 @@
+package org.orderhub.pr.product.service;
+
+public interface ProductImageService {
+}

--- a/src/main/java/org/orderhub/pr/product/service/ProductImageUploadService.java
+++ b/src/main/java/org/orderhub/pr/product/service/ProductImageUploadService.java
@@ -1,0 +1,11 @@
+package org.orderhub.pr.product.service;
+
+import org.orderhub.pr.product.dto.request.ProductImageRegisterRequest;
+import org.orderhub.pr.product.dto.request.ProductImageUpdateRequest;
+
+import java.io.IOException;
+
+public interface ProductImageUploadService {
+    String registerProductImage(ProductImageRegisterRequest productImageRegisterRequest) throws IOException;
+    String updateProductImage(ProductImageUpdateRequest productImageUpdateRequest) throws IOException;
+}

--- a/src/main/java/org/orderhub/pr/product/service/ProductService.java
+++ b/src/main/java/org/orderhub/pr/product/service/ProductService.java
@@ -2,6 +2,7 @@ package org.orderhub.pr.product.service;
 
 import org.orderhub.pr.product.dto.request.ProductRegisterRequest;
 import org.orderhub.pr.product.dto.request.ProductSearchRequest;
+import org.orderhub.pr.product.dto.request.ProductUpdateRequest;
 import org.orderhub.pr.product.dto.response.ProductResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,4 +12,6 @@ public interface ProductService {
     Page<ProductResponse> getProductByPage(Pageable pageable, ProductSearchRequest searchRequest);
     Page<ProductResponse> getAllProducts(Pageable pageable);
     ProductResponse createProduct(ProductRegisterRequest request, MultipartFile productImage);
+    ProductResponse updateProduct(ProductUpdateRequest request, Long productId);
+
 }

--- a/src/main/java/org/orderhub/pr/product/service/ProductService.java
+++ b/src/main/java/org/orderhub/pr/product/service/ProductService.java
@@ -1,0 +1,4 @@
+package org.orderhub.pr.product.service;
+
+public interface ProductService {
+}

--- a/src/main/java/org/orderhub/pr/product/service/ProductService.java
+++ b/src/main/java/org/orderhub/pr/product/service/ProductService.java
@@ -1,4 +1,14 @@
 package org.orderhub.pr.product.service;
 
+import org.orderhub.pr.product.dto.request.ProductRegisterRequest;
+import org.orderhub.pr.product.dto.request.ProductSearchRequest;
+import org.orderhub.pr.product.dto.response.ProductResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
+
 public interface ProductService {
+    Page<ProductResponse> getProductByPage(Pageable pageable, ProductSearchRequest searchRequest);
+    Page<ProductResponse> getAllProducts(Pageable pageable);
+    ProductResponse createProduct(ProductRegisterRequest request, MultipartFile productImage);
 }

--- a/src/main/java/org/orderhub/pr/product/service/impl/ProductImageServiceImpl.java
+++ b/src/main/java/org/orderhub/pr/product/service/impl/ProductImageServiceImpl.java
@@ -1,0 +1,38 @@
+package org.orderhub.pr.product.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.orderhub.pr.product.domain.Product;
+import org.orderhub.pr.product.domain.ProductImage;
+import org.orderhub.pr.product.dto.request.ProductImageRegisterRequest;
+import org.orderhub.pr.product.repository.ProductRepository;
+import org.orderhub.pr.product.service.ProductImageService;
+import org.orderhub.pr.product.service.ProductImageUploadService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+
+import static org.orderhub.pr.product.exception.ExceptionMessage.PRODUCT_NOT_FOUND;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProductImageServiceImpl implements ProductImageService {
+
+    private final ProductImageUploadService productImageUploadService;
+    private final ProductRepository productRepository;
+
+    @Transactional
+    public void processProductImage(ProductImageRegisterRequest request) throws IOException {
+        String imageUrl = productImageUploadService.registerProductImage(request);
+
+        Product product = productRepository.findById(request.getProductId())
+                .orElseThrow(() -> new IllegalArgumentException(PRODUCT_NOT_FOUND));
+
+        product.updateProductImage(ProductImage.builder()
+                .imageUrl(imageUrl)
+                .build());
+
+        productRepository.save(product);
+    }
+}

--- a/src/main/java/org/orderhub/pr/product/service/impl/ProductImageServiceImpl.java
+++ b/src/main/java/org/orderhub/pr/product/service/impl/ProductImageServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.orderhub.pr.product.domain.Product;
 import org.orderhub.pr.product.domain.ProductImage;
 import org.orderhub.pr.product.dto.request.ProductImageRegisterRequest;
+import org.orderhub.pr.product.dto.request.ProductImageUpdateRequest;
 import org.orderhub.pr.product.repository.ProductRepository;
 import org.orderhub.pr.product.service.ProductImageService;
 import org.orderhub.pr.product.service.ProductImageUploadService;
@@ -28,6 +29,20 @@ public class ProductImageServiceImpl implements ProductImageService {
                 .orElseThrow(() -> new IllegalArgumentException(PRODUCT_NOT_FOUND));
 
         String imageUrl = productImageUploadService.registerProductImage(request);
+
+        product.updateProductImage(ProductImage.builder()
+                .imageUrl(imageUrl)
+                .build());
+
+        productRepository.save(product);
+    }
+
+    @Transactional
+    public void updateProductImage(ProductImageUpdateRequest request) throws IOException {
+        Product product = productRepository.findById(request.getProductId())
+                .orElseThrow(() -> new IllegalArgumentException(PRODUCT_NOT_FOUND));
+
+        String imageUrl = productImageUploadService.updateProductImage(request);
 
         product.updateProductImage(ProductImage.builder()
                 .imageUrl(imageUrl)

--- a/src/main/java/org/orderhub/pr/product/service/impl/ProductImageServiceImpl.java
+++ b/src/main/java/org/orderhub/pr/product/service/impl/ProductImageServiceImpl.java
@@ -24,10 +24,10 @@ public class ProductImageServiceImpl implements ProductImageService {
 
     @Transactional
     public void processProductImage(ProductImageRegisterRequest request) throws IOException {
-        String imageUrl = productImageUploadService.registerProductImage(request);
-
         Product product = productRepository.findById(request.getProductId())
                 .orElseThrow(() -> new IllegalArgumentException(PRODUCT_NOT_FOUND));
+
+        String imageUrl = productImageUploadService.registerProductImage(request);
 
         product.updateProductImage(ProductImage.builder()
                 .imageUrl(imageUrl)

--- a/src/main/java/org/orderhub/pr/product/service/impl/ProductServiceImpl.java
+++ b/src/main/java/org/orderhub/pr/product/service/impl/ProductServiceImpl.java
@@ -59,12 +59,14 @@ public class ProductServiceImpl implements ProductService {
                 .build();
         productRepository.save(product);
 
-        eventPublisher.publishEvent(ProductCreatedEvent.builder().imageRequest(
-                ProductImageRegisterRequest.builder()
-                        .productId(product.getId())
-                        .image(productImage)
-                        .build()
-        ));
+        eventPublisher.publishEvent(ProductCreatedEvent.builder()
+                .imageRequest(
+                    ProductImageRegisterRequest.builder()
+                            .productId(product.getId())
+                            .image(productImage)
+                            .build()
+                )
+                .build());
         return ProductResponse.from(product);
     }
 

--- a/src/main/java/org/orderhub/pr/product/service/impl/ProductServiceImpl.java
+++ b/src/main/java/org/orderhub/pr/product/service/impl/ProductServiceImpl.java
@@ -1,12 +1,14 @@
 package org.orderhub.pr.product.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.orderhub.pr.category.domain.Category;
 import org.orderhub.pr.category.service.CategoryService;
 import org.orderhub.pr.product.domain.Product;
 import org.orderhub.pr.product.domain.event.ProductCreatedEvent;
 import org.orderhub.pr.product.dto.request.ProductImageRegisterRequest;
 import org.orderhub.pr.product.dto.request.ProductRegisterRequest;
 import org.orderhub.pr.product.dto.request.ProductSearchRequest;
+import org.orderhub.pr.product.dto.request.ProductUpdateRequest;
 import org.orderhub.pr.product.dto.response.ProductResponse;
 import org.orderhub.pr.product.repository.CustomProductRepository;
 import org.orderhub.pr.product.repository.ProductRepository;
@@ -21,6 +23,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.orderhub.pr.product.exception.ExceptionMessage.PRODUCT_NOT_FOUND;
 
 
 @Service
@@ -56,6 +60,7 @@ public class ProductServiceImpl implements ProductService {
                 .category(categoryService.findById(request.getCategoryId()))
                 .conditionStatus(request.getConditionStatus())
                 .saleStatus(request.getSaleStatus())
+                .price(request.getPrice())
                 .build();
         productRepository.save(product);
 
@@ -69,6 +74,15 @@ public class ProductServiceImpl implements ProductService {
                 .build());
         return ProductResponse.from(product);
     }
+
+    @Transactional
+    public ProductResponse updateProduct(ProductUpdateRequest request, Long productId) {
+        Product product = productRepository.findById(productId).orElseThrow(() -> new IllegalArgumentException(PRODUCT_NOT_FOUND));
+        Category category = categoryService.findById(request.getCategoryId());
+        product.updateProduct(request, category);
+        return ProductResponse.from(product);
+    }
+
 
 
 

--- a/src/main/java/org/orderhub/pr/product/service/impl/ProductServiceImpl.java
+++ b/src/main/java/org/orderhub/pr/product/service/impl/ProductServiceImpl.java
@@ -44,7 +44,7 @@ public class ProductServiceImpl implements ProductService {
                 .filter(p -> !p.getSaleStatus().equals(SaleStatus.DELETED))
                 .map(ProductResponse::from)
                 .toList();
-        return new PageImpl<>(productResponses, pageable, productPage.getTotalElements());
+        return new PageImpl<>(productResponses, pageable, productResponses.size());
     }
 
     public Page<ProductResponse> getAllProducts(Pageable pageable) {
@@ -53,7 +53,7 @@ public class ProductServiceImpl implements ProductService {
                 .filter(p -> !p.getSaleStatus().equals(SaleStatus.DELETED))
                 .map(ProductResponse::from)
                 .toList();
-        return new PageImpl<>(productResponses, pageable, productPage.getTotalElements());
+        return new PageImpl<>(productResponses, pageable, productResponses.size());
     }
 
     public Page<ProductResponse> getDeletedProducts(Pageable pageable) {
@@ -62,7 +62,7 @@ public class ProductServiceImpl implements ProductService {
                 .filter(p -> p.getSaleStatus().equals(SaleStatus.DELETED))
                 .map(ProductResponse::from)
                 .toList();
-        return new PageImpl<>(productResponses, pageable, productPage.getTotalElements());
+        return new PageImpl<>(productResponses, pageable, productResponses.size());
     }
 
     @Transactional

--- a/src/main/java/org/orderhub/pr/product/service/impl/ProductServiceImpl.java
+++ b/src/main/java/org/orderhub/pr/product/service/impl/ProductServiceImpl.java
@@ -1,17 +1,22 @@
 package org.orderhub.pr.product.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.orderhub.pr.category.service.CategoryService;
 import org.orderhub.pr.product.domain.Product;
+import org.orderhub.pr.product.domain.event.ProductCreatedEvent;
+import org.orderhub.pr.product.dto.request.ProductRegisterRequest;
 import org.orderhub.pr.product.dto.request.ProductSearchRequest;
 import org.orderhub.pr.product.dto.response.ProductResponse;
 import org.orderhub.pr.product.repository.CustomProductRepository;
 import org.orderhub.pr.product.repository.ProductRepository;
 import org.orderhub.pr.product.service.ProductService;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -24,6 +29,8 @@ public class ProductServiceImpl implements ProductService {
 
     private final ProductRepository productRepository;
     private final CustomProductRepository customProductRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final CategoryService categoryService;
 
     public Page<ProductResponse> getProductByPage(Pageable pageable, ProductSearchRequest searchRequest) {
         Page<Product> productPage = customProductRepository.searchProducts(searchRequest, pageable);
@@ -40,6 +47,22 @@ public class ProductServiceImpl implements ProductService {
                 .toList();
         return new PageImpl<>(productResponses, pageable, productPage.getTotalElements());
     }
+
+    @Transactional
+    public ProductResponse createProduct(ProductRegisterRequest request, MultipartFile productImage) {
+        Product product = Product.builder()
+                .name(request.getName())
+                .category(categoryService.findById(request.getCategoryId()))
+                .conditionStatus(request.getConditionStatus())
+                .saleStatus(request.getSaleStatus())
+                .build();
+        productRepository.save(product);
+
+        eventPublisher.publishEvent(new ProductCreatedEvent(product.getId(), productImage));
+        return ProductResponse.from(product);
+    }
+
+
 
 
 

--- a/src/main/java/org/orderhub/pr/product/service/impl/ProductServiceImpl.java
+++ b/src/main/java/org/orderhub/pr/product/service/impl/ProductServiceImpl.java
@@ -1,0 +1,46 @@
+package org.orderhub.pr.product.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.orderhub.pr.product.domain.Product;
+import org.orderhub.pr.product.dto.request.ProductSearchRequest;
+import org.orderhub.pr.product.dto.response.ProductResponse;
+import org.orderhub.pr.product.repository.CustomProductRepository;
+import org.orderhub.pr.product.repository.ProductRepository;
+import org.orderhub.pr.product.service.ProductService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProductServiceImpl implements ProductService {
+
+    private final ProductRepository productRepository;
+    private final CustomProductRepository customProductRepository;
+
+    public Page<ProductResponse> getProductByPage(Pageable pageable, ProductSearchRequest searchRequest) {
+        Page<Product> productPage = customProductRepository.searchProducts(searchRequest, pageable);
+        List<ProductResponse> productResponses = productPage.getContent().stream()
+                .map(ProductResponse::from)
+                .toList();
+        return new PageImpl<>(productResponses, pageable, productPage.getTotalElements());
+    }
+
+    public Page<ProductResponse> getAllProducts(Pageable pageable) {
+        Page<Product> productPage = productRepository.findAll(pageable);
+        List<ProductResponse> productResponses = productPage.getContent().stream()
+                .map(ProductResponse::from)
+                .toList();
+        return new PageImpl<>(productResponses, pageable, productPage.getTotalElements());
+    }
+
+
+
+}

--- a/src/main/java/org/orderhub/pr/product/service/impl/ProductServiceImpl.java
+++ b/src/main/java/org/orderhub/pr/product/service/impl/ProductServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.orderhub.pr.category.service.CategoryService;
 import org.orderhub.pr.product.domain.Product;
 import org.orderhub.pr.product.domain.event.ProductCreatedEvent;
+import org.orderhub.pr.product.dto.request.ProductImageRegisterRequest;
 import org.orderhub.pr.product.dto.request.ProductRegisterRequest;
 import org.orderhub.pr.product.dto.request.ProductSearchRequest;
 import org.orderhub.pr.product.dto.response.ProductResponse;
@@ -58,7 +59,12 @@ public class ProductServiceImpl implements ProductService {
                 .build();
         productRepository.save(product);
 
-        eventPublisher.publishEvent(new ProductCreatedEvent(product.getId(), productImage));
+        eventPublisher.publishEvent(ProductCreatedEvent.builder().imageRequest(
+                ProductImageRegisterRequest.builder()
+                        .productId(product.getId())
+                        .image(productImage)
+                        .build()
+        ));
         return ProductResponse.from(product);
     }
 

--- a/src/main/java/org/orderhub/pr/product/service/impl/S3ProductImageServiceImpl.java
+++ b/src/main/java/org/orderhub/pr/product/service/impl/S3ProductImageServiceImpl.java
@@ -9,6 +9,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Utilities;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
@@ -47,7 +49,14 @@ public class S3ProductImageServiceImpl implements ProductImageUploadService {
                 .build();
         s3Client.putObject(putObjectRequest,
                 software.amazon.awssdk.core.sync.RequestBody.fromBytes(file.getBytes()));
-        URL fileUrl = s3Client.utilities().getUrl(builder -> builder.bucket(bucketName).key(fileKey));
+        S3Utilities s3Utilities = s3Client.utilities();
+
+        GetUrlRequest getUrlRequest = GetUrlRequest.builder()
+                .bucket(bucketName)
+                .key(fileKey)
+                .build();
+
+        URL fileUrl = s3Utilities.getUrl(getUrlRequest);
         return fileUrl.toExternalForm();
     }
 

--- a/src/main/java/org/orderhub/pr/product/service/impl/S3ProductImageServiceImpl.java
+++ b/src/main/java/org/orderhub/pr/product/service/impl/S3ProductImageServiceImpl.java
@@ -4,10 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.orderhub.pr.product.aop.annotation.ValidateImage;
 import org.orderhub.pr.product.dto.request.ProductImageRegisterRequest;
 import org.orderhub.pr.product.dto.request.ProductImageUpdateRequest;
-import org.orderhub.pr.product.service.ProductImageService;
+import org.orderhub.pr.product.service.ProductImageUploadService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -17,7 +16,7 @@ import java.net.URL;
 
 @Service
 @RequiredArgsConstructor
-public class S3ProductImageServiceImpl implements ProductImageService {
+public class S3ProductImageServiceImpl implements ProductImageUploadService {
 
     @Value("${aws.s3.bucket-name}")
     private String bucketName;

--- a/src/main/java/org/orderhub/pr/product/service/impl/S3ProductImageServiceImpl.java
+++ b/src/main/java/org/orderhub/pr/product/service/impl/S3ProductImageServiceImpl.java
@@ -1,0 +1,59 @@
+package org.orderhub.pr.product.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.orderhub.pr.product.aop.annotation.ValidateImage;
+import org.orderhub.pr.product.dto.request.ProductImageRegisterRequest;
+import org.orderhub.pr.product.dto.request.ProductImageUpdateRequest;
+import org.orderhub.pr.product.service.ProductImageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.net.URL;
+
+@Service
+@RequiredArgsConstructor
+public class S3ProductImageServiceImpl implements ProductImageService {
+
+    @Value("${aws.s3.bucket-name}")
+    private String bucketName;
+
+    private final S3Client s3Client;
+
+    @ValidateImage
+    public String registerProductImage(ProductImageRegisterRequest productImageRegisterRequest) throws IOException {
+        String fileKey = generateFileKey(productImageRegisterRequest.getProductId(), productImageRegisterRequest.getImage());
+        return uploadToS3(productImageRegisterRequest.getImage(), fileKey);
+    }
+
+    @ValidateImage
+    public String updateProductImage(ProductImageUpdateRequest productImageUpdateRequest) throws IOException {
+        String fileKey = generateFileKey(productImageUpdateRequest.getProductId(), productImageUpdateRequest.getImage());
+        return uploadToS3(productImageUpdateRequest.getImage(), fileKey);
+    }
+
+    private String generateFileKey(Long productId, MultipartFile file) {
+        return "products/" + productId + "/thumbnail." + getFileExtension(file);
+    }
+
+    private String uploadToS3(MultipartFile file, String fileKey) throws IOException {
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileKey)
+                .contentType(file.getContentType())
+                .build();
+        s3Client.putObject(putObjectRequest,
+                software.amazon.awssdk.core.sync.RequestBody.fromBytes(file.getBytes()));
+        URL fileUrl = s3Client.utilities().getUrl(builder -> builder.bucket(bucketName).key(fileKey));
+        return fileUrl.toExternalForm();
+    }
+
+    private String getFileExtension(MultipartFile file) {
+        String originalFilename = file.getOriginalFilename();
+        return originalFilename.substring(originalFilename.lastIndexOf(".") + 1).toLowerCase();
+    }
+}

--- a/src/main/java/org/orderhub/pr/product/service/listener/ProductEventListener.java
+++ b/src/main/java/org/orderhub/pr/product/service/listener/ProductEventListener.java
@@ -1,0 +1,28 @@
+package org.orderhub.pr.product.service.listener;
+
+import lombok.RequiredArgsConstructor;
+import org.orderhub.pr.product.domain.event.ProductCreatedEvent;
+import org.orderhub.pr.product.repository.ProductRepository;
+import org.orderhub.pr.product.service.ProductImageService;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class ProductEventListener {
+
+    private final ProductRepository productRepository;
+    private final ProductImageService productImageService;
+
+    @Async
+    @EventListener
+    @Transactional
+    public void handleProductCreated(ProductCreatedEvent event) {
+
+    }
+
+
+
+}

--- a/src/main/java/org/orderhub/pr/product/service/listener/ProductEventListener.java
+++ b/src/main/java/org/orderhub/pr/product/service/listener/ProductEventListener.java
@@ -2,27 +2,23 @@ package org.orderhub.pr.product.service.listener;
 
 import lombok.RequiredArgsConstructor;
 import org.orderhub.pr.product.domain.event.ProductCreatedEvent;
-import org.orderhub.pr.product.repository.ProductRepository;
 import org.orderhub.pr.product.service.ProductImageService;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
 
 @Component
 @RequiredArgsConstructor
 public class ProductEventListener {
 
-    private final ProductRepository productRepository;
     private final ProductImageService productImageService;
 
     @Async
     @EventListener
-    @Transactional
-    public void handleProductCreated(ProductCreatedEvent event) {
-
+    public void handleProductCreated(ProductCreatedEvent event) throws IOException {
+        productImageService.processProductImage(event.getImageRequest());
     }
-
-
 
 }

--- a/src/main/java/org/orderhub/pr/system/config/AsyncConfig.java
+++ b/src/main/java/org/orderhub/pr/system/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package org.orderhub.pr.system.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/org/orderhub/pr/system/config/AwsConfig.java
+++ b/src/main/java/org/orderhub/pr/system/config/AwsConfig.java
@@ -1,0 +1,35 @@
+package org.orderhub.pr.system.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+@RequiredArgsConstructor
+public class AwsConfig {
+
+    @Value("${aws.s3.region}")
+    private String region;
+
+    @Value("${aws.s3.access-key}")
+    private String accessKey;
+
+    @Value("${aws.s3.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)
+                ))
+                .build();
+    }
+
+}

--- a/src/main/java/org/orderhub/pr/system/config/EnvConfig.java
+++ b/src/main/java/org/orderhub/pr/system/config/EnvConfig.java
@@ -1,0 +1,14 @@
+package org.orderhub.pr.system.config;
+
+import io.github.cdimascio.dotenv.Dotenv;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class EnvConfig {
+    static {
+        Dotenv dotenv = Dotenv.load();
+        dotenv.entries().forEach(entry -> {
+            System.setProperty(entry.getKey(), entry.getValue());
+        });
+    }
+}

--- a/src/main/java/org/orderhub/pr/system/config/ImageConfig.java
+++ b/src/main/java/org/orderhub/pr/system/config/ImageConfig.java
@@ -1,0 +1,25 @@
+package org.orderhub.pr.system.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Getter
+@Component
+public class ImageConfig {
+    @Value("${aws.s3.max-file-size}")
+    private long maxFileSize;
+
+    @Value("${aws.s3.supported-extensions}")
+    private String supportedExtensions;
+
+    public Set<String> getSupportedExtensionsSet() {
+        return Arrays.stream(supportedExtensions.split(","))
+                .map(String::trim)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/org/orderhub/pr/system/config/QueryDslConfig.java
+++ b/src/main/java/org/orderhub/pr/system/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package org.orderhub.pr.system.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory queryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}

--- a/src/main/java/org/orderhub/pr/util/HashMapConverter.java
+++ b/src/main/java/org/orderhub/pr/util/HashMapConverter.java
@@ -1,0 +1,36 @@
+package org.orderhub.pr.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.orderhub.pr.util.exception.ExceptionMessage.COVERT_JSON_EXCEPTION_MESSAGE;
+
+@Converter(autoApply = true)
+public class HashMapConverter implements AttributeConverter<Map<String, Object>, String> {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(Map<String, Object> attribute) {
+        try {
+            return attribute == null ? "{}" : objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(COVERT_JSON_EXCEPTION_MESSAGE, e);
+        }
+    }
+
+    @Override
+    public Map<String, Object> convertToEntityAttribute(String dbData) {
+        try {
+            return dbData == null ? new HashMap<>() : objectMapper.readValue(dbData, HashMap.class);
+        } catch (IOException e) {
+            throw new RuntimeException(COVERT_JSON_EXCEPTION_MESSAGE, e);
+        }
+    }
+}

--- a/src/main/java/org/orderhub/pr/util/exception/ExceptionMessage.java
+++ b/src/main/java/org/orderhub/pr/util/exception/ExceptionMessage.java
@@ -1,0 +1,9 @@
+package org.orderhub.pr.util.exception;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ExceptionMessage {
+    public static String COVERT_JSON_EXCEPTION_MESSAGE = "해당 JSON 객체를 COVERT 할 수 없습니다.";
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,7 @@ aws:
     access-key: ${AWS_ACCESS_KEY}
     secret-key: ${AWS_SECRET_KEY}
     max-file-size: ${MAX_FILE_SIZE}
+    supported-extensions: jpg,jpeg,png,webp
 
 spring:
   datasource:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,16 @@
+aws:
+  s3:
+    bucket-name: ${AWS_S3_BUCKET_NAME}
+    region: ${AWS_S3_REGION}
+    access-key: ${AWS_ACCESS_KEY}
+    secret-key: ${AWS_SECRET_KEY}
+    max-file-size: ${MAX_FILE_SIZE}
+
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/orderHub
-    username: cassidy65
-    password: cassidy65!
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
   jpa:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,19 @@
-spring.application.name=pr
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/orderHub
+    username: cassidy65
+    password: cassidy65!
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100
+
+server:
+  port: 8080

--- a/src/test/java/org/orderhub/pr/PrApplicationTests.java
+++ b/src/test/java/org/orderhub/pr/PrApplicationTests.java
@@ -6,8 +6,4 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class PrApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
-
 }

--- a/src/test/java/org/orderhub/pr/category/domain/CategoryTest.java
+++ b/src/test/java/org/orderhub/pr/category/domain/CategoryTest.java
@@ -7,6 +7,8 @@ import org.orderhub.pr.category.exception.ExceptionMessage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.orderhub.pr.category.exception.ExceptionMessage.MAJOR_CANNOT_BE_CHILD;
+import static org.orderhub.pr.category.exception.ExceptionMessage.MINOR_CANNOT_BE_PARENT;
 
 class CategoryTest {
 
@@ -105,6 +107,39 @@ class CategoryTest {
         assertThat(subCategory.getName()).isEqualTo("Updated Sub");
         assertThat(subCategory.getType()).isEqualTo(CategoryType.MINOR);
         assertThat(subCategory.getParent()).isEqualTo(newParent);
+    }
+
+    @Test
+    @DisplayName("대분류(MAJOR)는 부모를 가질 수 없음")
+    void shouldThrowExceptionWhenMajorCategoryHasParent() {
+        // Given
+        Category invalidMajorCategory = Category.builder()
+                .id(4L)
+                .name("Invalid Major")
+                .parent(middleCategory) // ✅ 부모가 있는 MAJOR 카테고리
+                .type(CategoryType.MAJOR)
+                .build();
+
+        // When & Then
+        assertThatThrownBy(() -> invalidMajorCategory.applyUpdate("Invalid Major", CategoryType.MAJOR, middleCategory))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(MAJOR_CANNOT_BE_CHILD);
+    }
+
+    @Test
+    @DisplayName("소분류(MINOR)는 자식을 가질 수 없음")
+    void shouldThrowExceptionWhenSubCategoryHasChildren() {
+        // Given
+        Category invalidChild = Category.builder()
+                .id(5L)
+                .name("Invalid Child")
+                .type(CategoryType.MINOR)
+                .build();
+
+        // When & Then
+        assertThatThrownBy(() -> subCategory.addChild(invalidChild))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(MINOR_CANNOT_BE_PARENT);
     }
 
 }

--- a/src/test/java/org/orderhub/pr/category/domain/CategoryTest.java
+++ b/src/test/java/org/orderhub/pr/category/domain/CategoryTest.java
@@ -1,0 +1,110 @@
+package org.orderhub.pr.category.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.orderhub.pr.category.exception.ExceptionMessage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CategoryTest {
+
+    private Category majorCategory;
+    private Category middleCategory;
+    private Category subCategory;
+
+    @BeforeEach
+    void setUp() {
+        majorCategory = Category.builder()
+                .id(1L)
+                .name("Major Category")
+                .type(CategoryType.MAJOR)
+                .build();
+
+        middleCategory = Category.builder()
+                .id(2L)
+                .name("Middle Category")
+                .parent(majorCategory)
+                .type(CategoryType.MIDDLE)
+                .build();
+
+        subCategory = Category.builder()
+                .id(3L)
+                .name("Sub Category")
+                .parent(middleCategory)
+                .type(CategoryType.MINOR)
+                .build();
+    }
+
+    @Test
+    @DisplayName("카테고리를 정상적으로 생성할 수 있는지 검증")
+    void shouldCreateCategorySuccessfully() {
+        // Then
+        assertThat(majorCategory.getName()).isEqualTo("Major Category");
+        assertThat(majorCategory.getParent()).isNull();
+        assertThat(middleCategory.getParent()).isEqualTo(majorCategory);
+        assertThat(subCategory.getParent()).isEqualTo(middleCategory);
+    }
+
+    @Test
+    @DisplayName("자신을 부모로 설정하면 예외 발생")
+    void shouldThrowExceptionWhenSettingSelfAsParent() {
+        // When & Then
+        assertThatThrownBy(() -> subCategory.applyUpdate("Sub Updated", CategoryType.MINOR, subCategory))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(ExceptionMessage.CANNOT_BE_YOUR_OWN_PARENT);
+    }
+
+    @Test
+    @DisplayName("자신을 자식으로 추가하면 예외 발생")
+    void shouldThrowExceptionWhenAddingSelfAsChild() {
+        // When & Then
+        assertThatThrownBy(() -> subCategory.addChild(subCategory))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(ExceptionMessage.CANNOT_BE_YOUR_OWN_CHILD);
+    }
+
+    @Test
+    @DisplayName("카테고리 삭제 후 상태가 DELETED인지 확인")
+    void shouldDeleteCategorySuccessfully() {
+        // When
+        subCategory.delete();
+
+        // Then
+        assertThat(subCategory.getStatus()).isEqualTo(CategoryStatus.DELETED);
+    }
+
+    @Test
+    @DisplayName("카테고리 복원 후 상태가 ACTIVE인지 확인")
+    void shouldRestoreCategorySuccessfully() {
+        // Given
+        subCategory.delete();
+
+        // When
+        subCategory.restore();
+
+        // Then
+        assertThat(subCategory.getStatus()).isEqualTo(CategoryStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("카테고리 정보를 업데이트하면 정상적으로 변경되는지 검증")
+    void shouldUpdateCategorySuccessfully() {
+        // Given
+        Category newParent = Category.builder()
+                .id(4L)
+                .name("New Parent Category")
+                .type(CategoryType.MIDDLE)
+                .build();
+
+        // When
+        subCategory.applyUpdate("Updated Sub", CategoryType.MINOR, newParent);
+
+        // Then
+        assertThat(subCategory.getName()).isEqualTo("Updated Sub");
+        assertThat(subCategory.getType()).isEqualTo(CategoryType.MINOR);
+        assertThat(subCategory.getParent()).isEqualTo(newParent);
+    }
+
+}

--- a/src/test/java/org/orderhub/pr/category/service/impl/CategoryServiceImplDeleteTest.java
+++ b/src/test/java/org/orderhub/pr/category/service/impl/CategoryServiceImplDeleteTest.java
@@ -1,0 +1,105 @@
+package org.orderhub.pr.category.service.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.orderhub.pr.category.domain.Category;
+import org.orderhub.pr.category.domain.CategoryStatus;
+import org.orderhub.pr.category.domain.CategoryType;
+import org.orderhub.pr.category.exception.ExceptionMessage;
+import org.orderhub.pr.category.repository.CategoryRepository;
+
+import java.util.Optional;
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+public class CategoryServiceImplDeleteTest {
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @InjectMocks
+    private CategoryServiceImpl categoryService;
+
+    private Category category;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        category = Category.builder()
+                .id(1L)
+                .name("전자제품")
+                .type(CategoryType.MAJOR)
+                .parent(null)
+                .build();
+    }
+
+    @Test
+    @DisplayName("카테고리 삭제 성공")
+    void categoryDeleteSuccess() {
+        // Given
+        when(categoryRepository.findById(1L)).thenReturn(Optional.of(category));
+
+        // When
+        categoryService.categoryDelete(1L);
+
+        // Then
+        assertThat(category.getStatus()).isEqualTo(CategoryStatus.DELETED);
+
+        verify(categoryRepository, times(1)).findById(1L);
+        verifyNoMoreInteractions(categoryRepository);
+    }
+
+
+    @Test
+    @DisplayName("카테고리 복구 성공")
+    void categoryRestoreSuccess() {
+        // Given (초기 상태: 삭제됨)
+        category.delete(); // 미리 상태를 DELETED로 변경
+        when(categoryRepository.findById(1L)).thenReturn(Optional.of(category));
+
+        // When
+        categoryService.categoryRestore(1L);
+
+        // Then
+        assertThat(category.getStatus()).isEqualTo(CategoryStatus.ACTIVE);
+
+        verify(categoryRepository, times(1)).findById(1L);
+        verifyNoMoreInteractions(categoryRepository);
+    }
+
+    @Test
+    @DisplayName("카테고리 삭제 실패, 존재하지 않음")
+    void categoryDeleteFail_notExist() {
+        // Given
+        when(categoryRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> categoryService.categoryDelete(999L))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage(ExceptionMessage.NO_SUCH_CATEGORY);
+
+        verify(categoryRepository, times(1)).findById(999L);
+    }
+
+    @Test
+    @DisplayName("카테고리 복구 실패, 존재하지 않음")
+    void categoryRestoreFail_notExist() {
+        // Given
+        when(categoryRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> categoryService.categoryRestore(999L))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage(ExceptionMessage.NO_SUCH_CATEGORY);
+
+        verify(categoryRepository, times(1)).findById(999L);
+    }
+}

--- a/src/test/java/org/orderhub/pr/category/service/impl/CategoryServiceImplReadTest.java
+++ b/src/test/java/org/orderhub/pr/category/service/impl/CategoryServiceImplReadTest.java
@@ -1,0 +1,116 @@
+package org.orderhub.pr.category.service.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.orderhub.pr.category.domain.Category;
+import org.orderhub.pr.category.domain.CategoryStatus;
+import org.orderhub.pr.category.domain.CategoryType;
+import org.orderhub.pr.category.dto.response.CategoryTreeResponse;
+import org.orderhub.pr.category.repository.CategoryRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class CategoryServiceImplReadTest {
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @InjectMocks
+    private CategoryServiceImpl categoryService;
+
+    private Category majorCategory;
+    private Category middleCategory;
+    private Category minorCategory;
+    private Category deletedCategory;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        majorCategory = Category.builder()
+                .id(1L)
+                .name("전자제품")
+                .parent(null)
+                .type(CategoryType.MAJOR)
+                .build();
+
+        middleCategory = Category.builder()
+                .id(2L)
+                .name("스마트폰")
+                .type(CategoryType.MIDDLE)
+                .parent(majorCategory)
+                .build();
+
+        minorCategory = Category.builder()
+                .id(3L)
+                .name("아이폰")
+                .type(CategoryType.MINOR)
+                .parent(middleCategory)
+                .build();
+
+        deletedCategory = Category.builder()
+                .id(4L)
+                .name("패션")
+                .type(CategoryType.MAJOR)
+                .parent(null)
+                .build();
+
+        deletedCategory.delete();
+
+        majorCategory.addChild(middleCategory);
+        middleCategory.addChild(minorCategory);
+    }
+
+    @Test
+    @DisplayName("모든 카테고리 조회 성공")
+    void allCategoryReadSuccess() {
+        // Given
+        when(categoryRepository.findAllWithChildren()).thenReturn(List.of(majorCategory, deletedCategory));
+
+        // When
+        List<CategoryTreeResponse> result = categoryService.getAllCategories();
+
+        // Then
+        assertThat(result).hasSize(2); // ✅ 전자제품, 패션 포함
+        assertThat(result.get(0).getName()).isEqualTo("전자제품");
+        assertThat(result.get(1).getName()).isEqualTo("패션");
+
+        assertThat(result.get(0).getChildren()).hasSize(1);
+        assertThat(result.get(0).getChildren().get(0).getName()).isEqualTo("스마트폰");
+        assertThat(result.get(0).getChildren().get(0).getChildren().get(0).getName()).isEqualTo("아이폰");
+
+        verify(categoryRepository, times(1)).findAllWithChildren();
+        verify(categoryRepository, never()).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("ACTIVE 상태의 카테고리 조회 성공")
+    void activeCategoryReadSuccess() {
+        // Given
+        when(categoryRepository.findWithChildrenAndStatus(CategoryStatus.ACTIVE)).thenReturn(List.of(majorCategory));
+
+        // When
+        List<CategoryTreeResponse> result = categoryService.getAllCategoriesByActive();
+
+        // Then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getName()).isEqualTo("전자제품");
+
+        assertThat(result.get(0).getChildren()).hasSize(1);
+        assertThat(result.get(0).getChildren().get(0).getName()).isEqualTo("스마트폰");
+        assertThat(result.get(0).getChildren().get(0).getChildren().get(0).getName()).isEqualTo("아이폰");
+
+        verify(categoryRepository, times(1)).findWithChildrenAndStatus(CategoryStatus.ACTIVE);
+        verify(categoryRepository, never()).save(any(Category.class));
+        assertThat(result).extracting(CategoryTreeResponse::getName)
+                .doesNotContain("패션");
+
+    }
+}

--- a/src/test/java/org/orderhub/pr/category/service/impl/CategoryServiceImplRegisterTest.java
+++ b/src/test/java/org/orderhub/pr/category/service/impl/CategoryServiceImplRegisterTest.java
@@ -23,7 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
 
-class CategoryServiceImplTest {
+class CategoryServiceImplRegisterTest {
 
     @Mock
     private CategoryRepository categoryRepository;

--- a/src/test/java/org/orderhub/pr/category/service/impl/CategoryServiceImplTest.java
+++ b/src/test/java/org/orderhub/pr/category/service/impl/CategoryServiceImplTest.java
@@ -3,22 +3,19 @@ package org.orderhub.pr.category.service.impl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.orderhub.pr.category.domain.Category;
 import org.orderhub.pr.category.domain.CategoryType;
-import org.orderhub.pr.category.dto.CategoryRegisterRequest;
-import org.orderhub.pr.category.dto.CategoryRegisterResponse;
+import org.orderhub.pr.category.dto.request.CategoryRegisterRequest;
+import org.orderhub.pr.category.dto.response.CategoryRegisterResponse;
 import org.orderhub.pr.category.exception.ExceptionMessage;
 import org.orderhub.pr.category.repository.CategoryRepository;
 
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/src/test/java/org/orderhub/pr/category/service/impl/CategoryServiceImplTest.java
+++ b/src/test/java/org/orderhub/pr/category/service/impl/CategoryServiceImplTest.java
@@ -1,0 +1,113 @@
+package org.orderhub.pr.category.service.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.orderhub.pr.category.domain.Category;
+import org.orderhub.pr.category.domain.CategoryType;
+import org.orderhub.pr.category.dto.CategoryRegisterRequest;
+import org.orderhub.pr.category.dto.CategoryRegisterResponse;
+import org.orderhub.pr.category.exception.ExceptionMessage;
+import org.orderhub.pr.category.repository.CategoryRepository;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+class CategoryServiceImplTest {
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @InjectMocks
+    private CategoryServiceImpl categoryService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("카테고리 등록 성공 부모 없음")
+    void categoryRegisterSuccess_withoutParent() {
+        // Given
+        CategoryRegisterRequest request = new CategoryRegisterRequest("전자제품", null, "MAJOR");
+        Category category = Category.builder()
+                .id(1L)
+                .name("전자제품")
+                .parent(null)
+                .type(CategoryType.MAJOR)
+                .build();
+        when(categoryRepository.save(any(Category.class))).thenReturn(category);
+
+        // When
+        CategoryRegisterResponse response = categoryService.categoryRegister(request);
+
+        // Then
+        assertThat(response.getName()).isEqualTo("전자제품");
+        assertThat(response.getCategoryType()).isEqualTo(CategoryType.MAJOR.toString());
+        assertThat(response.getParentId()).isNull();
+
+        verify(categoryRepository, times(1)).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("카테고리 등록 성공 부모 존재")
+    void categoryRegisterSuccess_withParent() {
+        // Given (부모 카테고리 생성)
+        Category parentCategory = Category.builder()
+                .id(1L)
+                .name("전자제품")
+                .parent(null)
+                .type(CategoryType.MAJOR)
+                .build();
+        when(categoryRepository.findById(anyLong())).thenReturn(Optional.of(parentCategory));
+
+        CategoryRegisterRequest request = new CategoryRegisterRequest("스마트폰", 1L, "MIDDLE");
+        Category newCategory = Category.builder()
+                .name("스마트폰")
+                .parent(parentCategory)
+                .type(CategoryType.MIDDLE)
+                .build();
+        when(categoryRepository.save(any(Category.class))).thenReturn(newCategory);
+
+        // When
+        CategoryRegisterResponse response = categoryService.categoryRegister(request);
+
+        // Then
+        assertThat(response.getName()).isEqualTo("스마트폰");
+        assertThat(response.getCategoryType()).isEqualTo(CategoryType.MIDDLE.toString());
+        assertThat(response.getParentId()).isEqualTo(1L);
+
+        verify(categoryRepository, times(1)).findById(1L);
+        verify(categoryRepository, times(1)).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("카테고리 등록 실패 부모 카테고리 없음")
+    void categoryRegisterFail_withoutParent() {
+        // Given
+        CategoryRegisterRequest request = new CategoryRegisterRequest("스마트폰", 999L, "MIDDLE");
+        when(categoryRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // When & Then (예외 발생 검증)
+        assertThatThrownBy(() -> categoryService.categoryRegister(request))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage(ExceptionMessage.NO_SUCH_CATEGORY);
+
+        verify(categoryRepository, times(1)).findById(999L);
+        verify(categoryRepository, never()).save(any(Category.class));
+    }
+}

--- a/src/test/java/org/orderhub/pr/category/service/impl/CategoryServiceImplUpdateTest.java
+++ b/src/test/java/org/orderhub/pr/category/service/impl/CategoryServiceImplUpdateTest.java
@@ -1,0 +1,129 @@
+package org.orderhub.pr.category.service.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.orderhub.pr.category.domain.Category;
+import org.orderhub.pr.category.domain.CategoryType;
+import org.orderhub.pr.category.dto.request.CategoryUpdateRequest;
+import org.orderhub.pr.category.dto.response.CategoryUpdateResponse;
+import org.orderhub.pr.category.exception.ExceptionMessage;
+import org.orderhub.pr.category.repository.CategoryRepository;
+
+import java.util.Optional;
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class CategoryServiceImplUpdateTest {
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @InjectMocks
+    private CategoryServiceImpl categoryService;
+
+    private Category majorCategory;
+    private Category middleCategory;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        majorCategory = Category.builder()
+                .id(1L)
+                .name("전자제품")
+                .type(CategoryType.MAJOR)
+                .parent(null)
+                .build();
+
+        middleCategory = Category.builder()
+                .id(2L)
+                .name("스마트폰")
+                .type(CategoryType.MIDDLE)
+                .parent(majorCategory)
+                .build();
+    }
+
+    @Test
+    @DisplayName("카테고리 업데이트 성공")
+    void categoryUpdateSuccess() {
+        // Given
+        when(categoryRepository.findById(2L)).thenReturn(Optional.of(middleCategory));
+        when(categoryRepository.findById(1L)).thenReturn(Optional.of(majorCategory));
+
+        // 요청 데이터
+        CategoryUpdateRequest request = new CategoryUpdateRequest(2L, "변경된 스마트폰", 1L, "MIDDLE");
+
+        // When (메서드 실행)
+        CategoryUpdateResponse response = categoryService.categoryUpdate(request);
+
+        // Then (검증)
+        assertThat(response.getId()).isEqualTo(2L);
+        assertThat(response.getName()).isEqualTo("변경된 스마트폰");
+        assertThat(response.getParentId()).isEqualTo(1L);
+        assertThat(response.getCategoryType()).isEqualTo("MIDDLE");
+
+        verify(categoryRepository, times(1)).findById(2L);
+        verify(categoryRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("카테고리 업데이트 성공 부모없음")
+    void categoryUpdateSuccess_withoutParent() {
+        // Given
+        when(categoryRepository.findById(1L)).thenReturn(Optional.of(majorCategory));
+
+        CategoryUpdateRequest request = new CategoryUpdateRequest(1L, "변경된 전자제품", null, "MAJOR");
+
+        // When
+        CategoryUpdateResponse response = categoryService.categoryUpdate(request);
+
+        // Then
+        assertThat(response.getId()).isEqualTo(1L);
+        assertThat(response.getName()).isEqualTo("변경된 전자제품");
+        assertThat(response.getParentId()).isNull();
+        assertThat(response.getCategoryType()).isEqualTo("MAJOR");
+
+        verify(categoryRepository, times(1)).findById(1L);
+        verify(categoryRepository, never()).findById(null); // 부모가 없으므로 호출되지 않아야 함
+    }
+
+    @Test
+    @DisplayName("카테고리 업데이트 실패, 존재하지 않음")
+    void categoryUpdateFail() {
+        // Given
+        when(categoryRepository.findById(999L)).thenReturn(Optional.empty());
+
+        CategoryUpdateRequest request = new CategoryUpdateRequest(999L, "없는 카테고리", null, "MAJOR");
+
+        // When & Then (예외 검증)
+        assertThatThrownBy(() -> categoryService.categoryUpdate(request))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage(ExceptionMessage.NO_SUCH_CATEGORY);
+
+        verify(categoryRepository, times(1)).findById(999L);
+        verify(categoryRepository, never()).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("카테고리 업데이트 실패, 자기자신을 부모로 설정")
+    void categoryUpdateFail_beOwnParent() {
+        // Given
+        when(categoryRepository.findById(1L)).thenReturn(Optional.of(majorCategory));
+
+        CategoryUpdateRequest request = new CategoryUpdateRequest(1L, "변경된 전자제품", 1L, "MAJOR");
+
+        // When & Then (예외 검증)
+        assertThatThrownBy(() -> categoryService.categoryUpdate(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(ExceptionMessage.CANNOT_BE_YOUR_OWN_PARENT);
+
+        verify(categoryRepository, times(2)).findById(1L);
+        verify(categoryRepository, never()).save(any(Category.class));
+    }
+}

--- a/src/test/java/org/orderhub/pr/product/aop/ImageValidationAspectTest.java
+++ b/src/test/java/org/orderhub/pr/product/aop/ImageValidationAspectTest.java
@@ -1,0 +1,127 @@
+package org.orderhub.pr.product.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.orderhub.pr.system.config.ImageConfig;
+import org.orderhub.pr.product.exception.ExceptionMessage;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+class ImageValidationAspectTest {
+
+    private ImageValidationAspect imageValidationAspect;
+    private ImageConfig imageConfig;
+    private ProceedingJoinPoint proceedingJoinPoint;
+    private MultipartFile mockFile;
+
+    @BeforeEach
+    void setUp() {
+        // ImageConfig 모킹
+        imageConfig = mock(ImageConfig.class);
+        when(imageConfig.getMaxFileSize()).thenReturn(5_242_880L); // 5MB
+        when(imageConfig.getSupportedExtensionsSet()).thenReturn(Set.of("jpg", "jpeg", "png", "webp"));
+
+        // AOP 인스턴스 생성
+        imageValidationAspect = new ImageValidationAspect(imageConfig);
+
+        // Mock 파일 생성
+        mockFile = mock(MultipartFile.class);
+        proceedingJoinPoint = mock(ProceedingJoinPoint.class);
+    }
+
+    @Test
+    @DisplayName("파일 크기가 허용 범위 내일 때 정상 동작")
+    void shouldAllowValidFileSize() throws Throwable {
+        // Given
+        when(mockFile.getSize()).thenReturn(1_000_000L); // 1MB
+        when(mockFile.getOriginalFilename()).thenReturn("test.jpg");
+        Object[] args = {mockFile};
+        when(proceedingJoinPoint.getArgs()).thenReturn(args);
+
+        // When & Then
+        imageValidationAspect.validateImageSize(proceedingJoinPoint);
+        verify(proceedingJoinPoint, times(1)).proceed(args);
+    }
+
+    @Test
+    @DisplayName("파일 크기가 초과될 경우 예외 발생")
+    void shouldThrowExceptionWhenFileSizeExceedsLimit() {
+        // Given
+        when(mockFile.getSize()).thenReturn(10_000_000L); // 10MB
+        when(mockFile.getOriginalFilename()).thenReturn("test.jpg");
+        Object[] args = {mockFile};
+        when(proceedingJoinPoint.getArgs()).thenReturn(args);
+
+        // When & Then
+        assertThatThrownBy(() -> imageValidationAspect.validateImageSize(proceedingJoinPoint))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(ExceptionMessage.FILE_SIZE_EXCEEDED);
+    }
+
+    @Test
+    @DisplayName("파일 확장자가 허용된 경우 정상 동작")
+    void shouldAllowValidFileExtension() throws Throwable {
+        // Given
+        when(mockFile.getSize()).thenReturn(1_000_000L); // 1MB
+        when(mockFile.getOriginalFilename()).thenReturn("test.png");
+        Object[] args = {mockFile};
+        when(proceedingJoinPoint.getArgs()).thenReturn(args);
+
+        // When & Then
+        imageValidationAspect.validateImageSize(proceedingJoinPoint);
+        verify(proceedingJoinPoint, times(1)).proceed(args);
+    }
+
+    @Test
+    @DisplayName("파일 확장자가 허용되지 않은 경우 예외 발생")
+    void shouldThrowExceptionWhenFileExtensionIsNotAllowed() {
+        // Given
+        when(mockFile.getSize()).thenReturn(1_000_000L); // 1MB
+        when(mockFile.getOriginalFilename()).thenReturn("test.txt");
+        Object[] args = {mockFile};
+        when(proceedingJoinPoint.getArgs()).thenReturn(args);
+
+        // When & Then
+        assertThatThrownBy(() -> imageValidationAspect.validateImageSize(proceedingJoinPoint))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(ExceptionMessage.UNSUPPORTED_FILE_EXTENSIONS);
+    }
+
+    @Test
+    @DisplayName("파일 이름이 없는 경우 예외 발생")
+    void shouldThrowExceptionWhenFileNameIsNull() {
+        // Given
+        when(mockFile.getSize()).thenReturn(1_000_000L); // 1MB
+        when(mockFile.getOriginalFilename()).thenReturn(null);
+        Object[] args = {mockFile};
+        when(proceedingJoinPoint.getArgs()).thenReturn(args);
+
+        // When & Then
+        assertThatThrownBy(() -> imageValidationAspect.validateImageSize(proceedingJoinPoint))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(ExceptionMessage.INVALID_FILE_FORMAT);
+    }
+
+    @Test
+    @DisplayName("파일 이름에 확장자가 없는 경우 예외 발생")
+    void shouldThrowExceptionWhenFileNameHasNoExtension() {
+        // Given
+        when(mockFile.getSize()).thenReturn(1_000_000L); // 1MB
+        when(mockFile.getOriginalFilename()).thenReturn("testfile");
+        Object[] args = {mockFile};
+        when(proceedingJoinPoint.getArgs()).thenReturn(args);
+
+        // When & Then
+        assertThatThrownBy(() -> imageValidationAspect.validateImageSize(proceedingJoinPoint))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(ExceptionMessage.INVALID_FILE_FORMAT);
+    }
+
+}

--- a/src/test/java/org/orderhub/pr/product/domain/ProductTest.java
+++ b/src/test/java/org/orderhub/pr/product/domain/ProductTest.java
@@ -1,0 +1,123 @@
+package org.orderhub.pr.product.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.orderhub.pr.category.domain.Category;
+import org.orderhub.pr.product.dto.request.ProductUpdateRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class ProductTest {
+
+    private Product product;
+    private Category majorCategory;
+    private Category middleCategory;
+    private Category subCategory;
+
+
+    @BeforeEach
+    void setUp() {
+        majorCategory = mock(Category.class);
+        when(majorCategory.getParent()).thenReturn(null);
+
+        middleCategory = mock(Category.class);
+        when(middleCategory.getParent()).thenReturn(majorCategory);
+
+        subCategory = mock(Category.class);
+        when(subCategory.getParent()).thenReturn(middleCategory);
+
+        product = Product.builder()
+                .name("Test Product")
+                .price("1000")
+                .image(ProductImage.builder().imageUrl("https://test.com/image.jpg").build())
+                .saleStatus(SaleStatus.FOR_SALE)
+                .conditionStatus(ConditionStatus.NEW)
+                .category(subCategory)
+                .build();
+    }
+
+    @Test
+    @DisplayName("대분류를 올바르게 가져오는지 테스트")
+    void shouldReturnMajorCategory() {
+        // When
+        Category major = product.getMajorCategory();
+
+        // Then
+        assertThat(major).isNotNull();
+        assertThat(major).isEqualTo(majorCategory);
+    }
+
+
+    @Test
+    @DisplayName("중분류를 올바르게 가져오는지 테스트")
+    void shouldReturnMiddleCategory() {
+        // When
+        Category middle = product.getMiddleCategory();
+
+        // Then
+        assertThat(middle).isNotNull();
+        assertThat(middle).isEqualTo(middleCategory);
+    }
+
+    @Test
+    @DisplayName("상품의 카테고리가 없을 때 대분류와 중분류가 null인지 테스트")
+    void shouldReturnNullWhenNoCategory() {
+        // Given
+        Product productWithoutCategory = Product.builder()
+                .name("Test Product")
+                .price("1000")
+                .saleStatus(SaleStatus.FOR_SALE)
+                .conditionStatus(ConditionStatus.NEW)
+                .category(null)
+                .build();
+
+        // When
+        Category major = productWithoutCategory.getMajorCategory();
+        Category middle = productWithoutCategory.getMiddleCategory();
+
+        // Then
+        assertThat(major).isNull();
+        assertThat(middle).isNull();
+    }
+
+    @Test
+    @DisplayName("상품 이미지 업데이트 테스트")
+    void shouldUpdateProductImage() {
+        // Given
+        ProductImage newImage = ProductImage.builder().imageUrl("https://test.com/new-image.jpg").build();
+
+        // When
+        product.updateProductImage(newImage);
+
+        // Then
+        assertThat(product.getImage()).isEqualTo(newImage);
+    }
+
+
+    @Test
+    @DisplayName("상품 정보 업데이트 테스트")
+    void shouldUpdateProductDetails() {
+        // Given
+        ProductUpdateRequest request = ProductUpdateRequest.builder()
+                .name("Updated Product")
+                .price("2000")
+                .saleStatus(SaleStatus.OUT_OF_STOCK)
+                .conditionStatus(ConditionStatus.NEW)
+                .categoryId(2L)
+                .build();
+
+        Category updatedCategory = mock(Category.class);
+
+        // When
+        product.updateProduct(request, updatedCategory);
+
+        // Then
+        assertThat(product.getName()).isEqualTo("Updated Product");
+        assertThat(product.getPrice()).isEqualTo("2000");
+        assertThat(product.getSaleStatus()).isEqualTo(SaleStatus.OUT_OF_STOCK);
+        assertThat(product.getConditionStatus()).isEqualTo(ConditionStatus.NEW);
+        assertThat(product.getCategory()).isEqualTo(updatedCategory);
+    }
+}

--- a/src/test/java/org/orderhub/pr/product/service/impl/ProductImageServiceImplCreateTest.java
+++ b/src/test/java/org/orderhub/pr/product/service/impl/ProductImageServiceImplCreateTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 import static org.orderhub.pr.product.exception.ExceptionMessage.PRODUCT_NOT_FOUND;
 
-class ProductImageServiceImplTest {
+class ProductImageServiceImplCreateTest {
 
     private ProductImageService productImageService;
 

--- a/src/test/java/org/orderhub/pr/product/service/impl/ProductImageServiceImplTest.java
+++ b/src/test/java/org/orderhub/pr/product/service/impl/ProductImageServiceImplTest.java
@@ -1,0 +1,126 @@
+package org.orderhub.pr.product.service.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.orderhub.pr.product.domain.Product;
+import org.orderhub.pr.product.domain.ProductImage;
+import org.orderhub.pr.product.dto.request.ProductImageRegisterRequest;
+import org.orderhub.pr.product.repository.ProductRepository;
+import org.orderhub.pr.product.service.ProductImageService;
+import org.orderhub.pr.product.service.ProductImageUploadService;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+import static org.orderhub.pr.product.exception.ExceptionMessage.PRODUCT_NOT_FOUND;
+
+class ProductImageServiceImplTest {
+
+    private ProductImageService productImageService;
+
+    @Mock
+    private ProductImageUploadService productImageUploadService;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        productImageService = new ProductImageServiceImpl(productImageUploadService, productRepository);
+    }
+
+    @Test
+    @DisplayName("이미지를 정상적으로 등록하고 상품 정보를 업데이트한다")
+    void shouldProcessProductImageSuccessfully() throws IOException {
+        // Given
+        Long productId = 1L;
+        MultipartFile mockFile = mock(MultipartFile.class);
+        when(mockFile.getOriginalFilename()).thenReturn("test.jpg");
+        when(mockFile.getBytes()).thenReturn("image content".getBytes());
+
+        ProductImageRegisterRequest request = ProductImageRegisterRequest.builder()
+                .productId(productId)
+                .image(mockFile)
+                .build();
+
+        String mockImageUrl = "https://s3.amazonaws.com/test-bucket/products/1/thumbnail.jpg";
+
+        Product mockProduct = mock(Product.class);
+        when(productRepository.findById(productId)).thenReturn(Optional.of(mockProduct));
+        when(productImageUploadService.registerProductImage(request)).thenReturn(mockImageUrl);
+
+        // When
+        productImageService.processProductImage(request);
+
+        // Then
+        verify(productImageUploadService, times(1)).registerProductImage(request);
+        verify(mockProduct, times(1)).updateProductImage(any(ProductImage.class));
+        verify(productRepository, times(1)).save(mockProduct);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 상품 ID로 요청 시 예외 발생")
+    void shouldThrowExceptionWhenProductNotFound() throws IOException {
+        // Given
+        Long nonExistentProductId = 999L;
+        MultipartFile mockFile = mock(MultipartFile.class);
+        when(mockFile.getOriginalFilename()).thenReturn("test.jpg");
+
+        ProductImageRegisterRequest request = ProductImageRegisterRequest.builder()
+                .productId(nonExistentProductId)
+                .image(mockFile)
+                .build();
+
+        when(productRepository.findById(nonExistentProductId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> productImageService.processProductImage(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(PRODUCT_NOT_FOUND);
+
+        verify(productImageUploadService, never()).registerProductImage(any());
+        verify(productRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("상품 이미지가 정상적으로 업데이트되는지 검증")
+    void shouldUpdateProductImageCorrectly() throws IOException {
+        // Given
+        Long productId = 2L;
+        MultipartFile mockFile = mock(MultipartFile.class);
+        when(mockFile.getOriginalFilename()).thenReturn("image.png");
+        when(mockFile.getBytes()).thenReturn("image content".getBytes());
+
+        ProductImageRegisterRequest request = ProductImageRegisterRequest.builder()
+                .productId(productId)
+                .image(mockFile)
+                .build();
+
+        String mockImageUrl = "https://s3.amazonaws.com/test-bucket/products/2/thumbnail.png";
+
+        Product mockProduct = mock(Product.class);
+        when(productRepository.findById(productId)).thenReturn(Optional.of(mockProduct));
+        when(productImageUploadService.registerProductImage(request)).thenReturn(mockImageUrl);
+
+        // When
+        productImageService.processProductImage(request);
+
+        // Then
+        ArgumentCaptor<ProductImage> captor = ArgumentCaptor.forClass(ProductImage.class);
+        verify(mockProduct, times(1)).updateProductImage(captor.capture());
+
+        ProductImage capturedImage = captor.getValue();
+        assertThat(capturedImage.getImageUrl()).isEqualTo(mockImageUrl);
+
+        verify(productRepository, times(1)).save(mockProduct);
+    }
+}

--- a/src/test/java/org/orderhub/pr/product/service/impl/ProductImageServiceImplUpdateTest.java
+++ b/src/test/java/org/orderhub/pr/product/service/impl/ProductImageServiceImplUpdateTest.java
@@ -1,0 +1,98 @@
+package org.orderhub.pr.product.service.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.orderhub.pr.product.domain.Product;
+import org.orderhub.pr.product.domain.ProductImage;
+import org.orderhub.pr.product.dto.request.ProductImageUpdateRequest;
+import org.orderhub.pr.product.repository.ProductRepository;
+import org.orderhub.pr.product.service.ProductImageService;
+import org.orderhub.pr.product.service.ProductImageUploadService;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+import static org.orderhub.pr.product.exception.ExceptionMessage.PRODUCT_NOT_FOUND;
+
+class ProductImageServiceImplUpdateTest {
+
+    private ProductImageService productImageService;
+
+    @Mock
+    private ProductImageUploadService productImageUploadService;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        productImageService = new ProductImageServiceImpl(productImageUploadService, productRepository);
+    }
+
+    @Test
+    @DisplayName("상품 이미지가 정상적으로 업데이트되는지 검증")
+    void shouldUpdateProductImageSuccessfully() throws IOException {
+        // Given
+        Long productId = 1L;
+        MultipartFile mockFile = mock(MultipartFile.class);
+        when(mockFile.getOriginalFilename()).thenReturn("updated-image.jpg");
+
+        ProductImageUpdateRequest request = ProductImageUpdateRequest.builder()
+                .productId(productId)
+                .image(mockFile)
+                .build();
+
+        String updatedImageUrl = "https://s3.amazonaws.com/test-bucket/products/1/updated-thumbnail.jpg";
+
+        Product mockProduct = mock(Product.class);
+        when(productRepository.findById(productId)).thenReturn(Optional.of(mockProduct));
+        when(productImageUploadService.updateProductImage(request)).thenReturn(updatedImageUrl);
+
+        // When
+        productImageService.updateProductImage(request);
+
+        // Then
+        ArgumentCaptor<ProductImage> imageCaptor = ArgumentCaptor.forClass(ProductImage.class);
+        verify(mockProduct, times(1)).updateProductImage(imageCaptor.capture());
+
+        // 이미지 URL이 정상적으로 업데이트되었는지 검증
+        ProductImage capturedImage = imageCaptor.getValue();
+        assertThat(capturedImage.getImageUrl()).isEqualTo(updatedImageUrl);
+
+        // `save()` 호출 검증
+        verify(productRepository, times(1)).save(mockProduct);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 상품 ID일 경우 예외 발생")
+    void shouldThrowExceptionWhenProductNotFound() throws IOException {
+        // Given
+        Long nonExistentProductId = 999L;
+        MultipartFile mockFile = mock(MultipartFile.class);
+
+        ProductImageUpdateRequest request = ProductImageUpdateRequest.builder()
+                .productId(nonExistentProductId)
+                .image(mockFile)
+                .build();
+
+        when(productRepository.findById(nonExistentProductId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> productImageService.updateProductImage(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(PRODUCT_NOT_FOUND);
+
+        // `updateProductImage()` 및 `save()`가 호출되지 않음
+        verify(productImageUploadService, never()).updateProductImage(any());
+        verify(productRepository, never()).save(any());
+    }
+}

--- a/src/test/java/org/orderhub/pr/product/service/impl/ProductServiceImplCreateTest.java
+++ b/src/test/java/org/orderhub/pr/product/service/impl/ProductServiceImplCreateTest.java
@@ -1,0 +1,115 @@
+package org.orderhub.pr.product.service.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.orderhub.pr.category.domain.Category;
+import org.orderhub.pr.category.service.CategoryService;
+import org.orderhub.pr.product.domain.ConditionStatus;
+import org.orderhub.pr.product.domain.Product;
+import org.orderhub.pr.product.domain.SaleStatus;
+import org.orderhub.pr.product.domain.event.ProductCreatedEvent;
+import org.orderhub.pr.product.dto.request.ProductImageRegisterRequest;
+import org.orderhub.pr.product.dto.request.ProductRegisterRequest;
+import org.orderhub.pr.product.dto.response.ProductResponse;
+import org.orderhub.pr.product.repository.CustomProductRepository;
+import org.orderhub.pr.product.repository.ProductRepository;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+
+class ProductServiceImplCreateTest {
+
+    private ProductServiceImpl productService;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private CustomProductRepository customProductRepository;
+
+    @Mock
+    private CategoryService categoryService;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        productService = new ProductServiceImpl(productRepository, customProductRepository, eventPublisher, categoryService);
+    }
+
+    @Test
+    @DisplayName("상품이 정상적으로 생성되고 이벤트가 발행되는지 검증")
+    void shouldCreateProductAndPublishEvent() {
+        // Given
+        ProductRegisterRequest request = ProductRegisterRequest.builder()
+                .name("Test Product")
+                .categoryId(1L)
+                .conditionStatus(ConditionStatus.NEW)
+                .saleStatus(SaleStatus.FOR_SALE)
+                .build();
+
+        MultipartFile mockFile = mock(MultipartFile.class);
+        Category mockCategory = mock(Category.class);
+        Product mockProduct = Product.builder()
+                .name(request.getName())
+                .category(mockCategory)
+                .conditionStatus(request.getConditionStatus())
+                .saleStatus(request.getSaleStatus())
+                .build();
+
+        when(categoryService.findById(request.getCategoryId())).thenReturn(mockCategory);
+        when(productRepository.save(any(Product.class))).thenReturn(mockProduct);
+
+        // When
+        ProductResponse response = productService.createProduct(request, mockFile);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getName()).isEqualTo("Test Product");
+
+        verify(productRepository, times(1)).save(any(Product.class));
+
+        // 이벤트 발행 검증
+        ArgumentCaptor<ProductCreatedEvent> eventCaptor = ArgumentCaptor.forClass(ProductCreatedEvent.class);
+        verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());
+
+        ProductImageRegisterRequest imageRequest = eventCaptor.getValue().getImageRequest();
+        assertThat(imageRequest.getProductId()).isEqualTo(mockProduct.getId());
+        assertThat(imageRequest.getImage()).isEqualTo(mockFile);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 카테고리를 사용하면 예외 발생")
+    void shouldThrowExceptionWhenCategoryNotFound() {
+        // Given
+        ProductRegisterRequest request = ProductRegisterRequest.builder()
+                .name("Test Product")
+                .categoryId(1L)
+                .conditionStatus(ConditionStatus.NEW)
+                .saleStatus(SaleStatus.FOR_SALE)
+                .build();
+
+        MultipartFile mockFile = mock(MultipartFile.class);
+
+        when(categoryService.findById(request.getCategoryId())).thenThrow(new IllegalArgumentException("CATEGORY_NOT_FOUND"));
+
+        // When & Then
+        assertThatThrownBy(() -> productService.createProduct(request, mockFile))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("CATEGORY_NOT_FOUND");
+
+        // productRepository.save() 및 eventPublisher 호출 안됨
+        verify(productRepository, never()).save(any());
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+}

--- a/src/test/java/org/orderhub/pr/product/service/impl/ProductServiceImplReadTest.java
+++ b/src/test/java/org/orderhub/pr/product/service/impl/ProductServiceImplReadTest.java
@@ -10,6 +10,7 @@ import org.mockito.MockitoAnnotations;
 import org.orderhub.pr.category.domain.Category;
 import org.orderhub.pr.product.domain.ConditionStatus;
 import org.orderhub.pr.product.domain.Product;
+import org.orderhub.pr.product.domain.ProductImage;
 import org.orderhub.pr.product.domain.SaleStatus;
 import org.orderhub.pr.product.dto.request.ProductSearchRequest;
 import org.orderhub.pr.product.dto.response.ProductResponse;
@@ -49,7 +50,7 @@ class ProductServiceImplReadTest {
         sampleProduct = Product.builder()
                 .name("Test Product")
                 .price("1000")
-                .imageUrl("test.jpg")
+                .image(ProductImage.builder().imageUrl("test.jpg").build())
                 .category(mockCategory)
                 .saleStatus(SaleStatus.FOR_SALE)
                 .conditionStatus(ConditionStatus.NEW)

--- a/src/test/java/org/orderhub/pr/product/service/impl/ProductServiceImplReadTest.java
+++ b/src/test/java/org/orderhub/pr/product/service/impl/ProductServiceImplReadTest.java
@@ -1,0 +1,105 @@
+package org.orderhub.pr.product.service.impl;
+
+import org.aspectj.lang.annotation.Before;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.orderhub.pr.category.domain.Category;
+import org.orderhub.pr.product.domain.ConditionStatus;
+import org.orderhub.pr.product.domain.Product;
+import org.orderhub.pr.product.domain.SaleStatus;
+import org.orderhub.pr.product.dto.request.ProductSearchRequest;
+import org.orderhub.pr.product.dto.response.ProductResponse;
+import org.orderhub.pr.product.repository.CustomProductRepository;
+import org.orderhub.pr.product.repository.ProductRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ProductServiceImplReadTest {
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private CustomProductRepository customProductRepository;
+
+    @InjectMocks
+    private ProductServiceImpl productService;
+
+    private Product sampleProduct;
+    private Pageable pageable;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        Category mockCategory = mock(Category.class);
+        when(mockCategory.getName()).thenReturn("Mock Category");
+
+        sampleProduct = Product.builder()
+                .name("Test Product")
+                .price("1000")
+                .imageUrl("test.jpg")
+                .category(mockCategory)
+                .saleStatus(SaleStatus.FOR_SALE)
+                .conditionStatus(ConditionStatus.NEW)
+                .build();
+
+        pageable = PageRequest.of(0, 10);
+    }
+
+    @Test
+    @DisplayName("모든 제품 페이징으로 가져오기")
+    void getAllProducts_ShouldReturnPagedProductResponses() {
+        // Given
+        List<Product> products = List.of(sampleProduct);
+        Page<Product> productPage = new PageImpl<>(products, pageable, products.size());
+
+        when(productRepository.findAll(pageable)).thenReturn(productPage);
+
+        // When
+        Page<ProductResponse> result = productService.getAllProducts(pageable);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).getName()).isEqualTo("Test Product");
+
+        // verify: repository가 호출되었는지 확인
+        verify(productRepository, times(1)).findAll(pageable);
+    }
+
+    @Test
+    @DisplayName("검색 조건에 맞는 상품들만 가져오는지 테스트")
+    void getProductByPage_ShouldReturnFilteredPagedProductResponses() {
+        // Given
+        ProductSearchRequest searchRequest = new ProductSearchRequest();
+        searchRequest.setName("Test");
+
+        List<Product> products = List.of(sampleProduct);
+        Page<Product> productPage = new PageImpl<>(products, pageable, products.size());
+
+        when(customProductRepository.searchProducts(searchRequest, pageable)).thenReturn(productPage);
+
+        // When
+        Page<ProductResponse> result = productService.getProductByPage(pageable, searchRequest);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).getName()).isEqualTo("Test Product");
+
+        // verify: repository가 호출되었는지 확인
+        verify(customProductRepository, times(1)).searchProducts(searchRequest, pageable);
+    }
+}

--- a/src/test/java/org/orderhub/pr/product/service/impl/ProductServiceImplUpdateTest.java
+++ b/src/test/java/org/orderhub/pr/product/service/impl/ProductServiceImplUpdateTest.java
@@ -1,0 +1,123 @@
+package org.orderhub.pr.product.service.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.orderhub.pr.category.domain.Category;
+import org.orderhub.pr.category.service.CategoryService;
+import org.orderhub.pr.product.domain.Product;
+import org.orderhub.pr.product.dto.request.ProductUpdateRequest;
+import org.orderhub.pr.product.dto.response.ProductResponse;
+import org.orderhub.pr.product.repository.ProductRepository;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+import static org.orderhub.pr.category.exception.ExceptionMessage.NO_SUCH_CATEGORY;
+import static org.orderhub.pr.product.exception.ExceptionMessage.PRODUCT_NOT_FOUND;
+
+
+class ProductServiceImplUpdateTest {
+
+    private ProductServiceImpl productService;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private CategoryService categoryService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        productService = new ProductServiceImpl(productRepository, null, null, categoryService);
+    }
+
+    @Test
+    @DisplayName("상품이 정상적으로 업데이트되는지 검증")
+    void shouldUpdateProductSuccessfully() {
+        // Given
+        Long productId = 1L;
+        Long categoryId = 2L;
+        String categoryName = "any category";
+        ProductUpdateRequest request = ProductUpdateRequest.builder()
+                .name("Updated Product")
+                .categoryId(2L)
+                .conditionStatus(null)
+                .saleStatus(null)
+                .price("5000")
+                .build();
+
+        Category mockCategory = mock(Category.class);
+        Product mockProduct = mock(Product.class);
+
+        when(productRepository.findById(productId)).thenReturn(Optional.of(mockProduct));
+        when(categoryService.findById(request.getCategoryId())).thenReturn(mockCategory);
+        when(mockProduct.getCategory()).thenReturn(mockCategory);
+        when(mockCategory.getId()).thenReturn(categoryId);
+        when(mockCategory.getName()).thenReturn(categoryName);
+        when(mockProduct.getName()).thenReturn("Updated Product");
+        when(mockProduct.getPrice()).thenReturn("5000");
+
+        // When
+        ProductResponse response = productService.updateProduct(request, productId);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getName()).isEqualTo("Updated Product");
+
+        // product.updateProduct() 호출 검증
+        verify(mockProduct, times(1)).updateProduct(request, mockCategory);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 상품 ID일 경우 예외 발생")
+    void shouldThrowExceptionWhenProductNotFound() {
+        // Given
+        Long nonExistentProductId = 999L;
+        ProductUpdateRequest request = ProductUpdateRequest.builder()
+                .name("Nonexistent Product")
+                .categoryId(1L)
+                .build();
+
+        when(productRepository.findById(nonExistentProductId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> productService.updateProduct(request, nonExistentProductId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(PRODUCT_NOT_FOUND);
+
+        // product.updateProduct() 및 save()가 호출되지 않음
+        verify(productRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 카테고리 ID일 경우 예외 발생")
+    void shouldThrowExceptionWhenCategoryNotFound() {
+        // Given
+        Long productId = 1L;
+        ProductUpdateRequest request = ProductUpdateRequest.builder()
+                .name("Updated Product")
+                .categoryId(999L) // 존재하지 않는 카테고리 ID
+                .build();
+
+        Product mockProduct = mock(Product.class);
+
+        when(productRepository.findById(productId)).thenReturn(Optional.of(mockProduct));
+        when(categoryService.findById(request.getCategoryId())).thenThrow(new IllegalArgumentException(NO_SUCH_CATEGORY));
+
+        // When & Then
+        assertThatThrownBy(() -> productService.updateProduct(request, productId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(NO_SUCH_CATEGORY);
+
+        // product.updateProduct() 및 save()가 호출되지 않음
+        verify(mockProduct, never()).updateProduct(any(), any());
+    }
+}

--- a/src/test/java/org/orderhub/pr/product/service/impl/S3ProductImageServiceImplTest.java
+++ b/src/test/java/org/orderhub/pr/product/service/impl/S3ProductImageServiceImplTest.java
@@ -1,0 +1,102 @@
+package org.orderhub.pr.product.service.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.orderhub.pr.product.dto.request.ProductImageRegisterRequest;
+import org.orderhub.pr.product.service.ProductImageUploadService;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Utilities;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+class S3ProductImageServiceImplTest {
+
+    @Mock
+    private S3Client s3Client;
+
+    private ProductImageUploadService productImageUploadService;
+
+    @BeforeEach
+    void setUp() throws NoSuchFieldException, IllegalAccessException {
+        MockitoAnnotations.openMocks(this);
+        productImageUploadService = new S3ProductImageServiceImpl(s3Client);
+
+        Field bucketNameField = S3ProductImageServiceImpl.class.getDeclaredField("bucketName");
+        bucketNameField.setAccessible(true);
+        bucketNameField.set(productImageUploadService, "test-bucket");
+
+        assertThat(bucketNameField.get(productImageUploadService)).isEqualTo("test-bucket");
+    }
+
+
+    @Test
+    @DisplayName("업로드된 파일의 URL을 반환하는지 검증")
+    void shouldReturnCorrectImageUrl() throws IOException {
+        // Given
+        MultipartFile mockFile = mock(MultipartFile.class);
+        when(mockFile.getBytes()).thenReturn("test image content".getBytes());
+        when(mockFile.getOriginalFilename()).thenReturn("test.jpg");
+        when(mockFile.getContentType()).thenReturn("image/jpeg");
+
+        ProductImageRegisterRequest request = ProductImageRegisterRequest.builder()
+                .productId(3L)
+                .image(mockFile)
+                .build();
+
+        URL mockUrl = new URL("https://s3.amazonaws.com/test-bucket/products/3/thumbnail.jpg");
+
+        S3Utilities mockS3Utilities = mock(S3Utilities.class);
+        when(s3Client.utilities()).thenReturn(mockS3Utilities);
+        when(mockS3Utilities.getUrl(any(GetUrlRequest.class))).thenReturn(mockUrl);
+
+        // When
+        String imageUrl = productImageUploadService.registerProductImage(request);
+
+        // Then
+        assertThat(imageUrl).isEqualTo("https://s3.amazonaws.com/test-bucket/products/3/thumbnail.jpg");
+    }
+
+    @Test
+    @DisplayName("파일이 정상적으로 S3에 업로드되는지 검증")
+    void shouldUploadImageToS3() throws IOException {
+        // Given
+        MultipartFile mockFile = mock(MultipartFile.class);
+        when(mockFile.getBytes()).thenReturn("test image content".getBytes());
+        when(mockFile.getOriginalFilename()).thenReturn("test.png");
+        when(mockFile.getContentType()).thenReturn("image/png");
+
+        ProductImageRegisterRequest request = ProductImageRegisterRequest.builder()
+                .productId(1L)
+                .image(mockFile)
+                .build();
+
+        URL mockUrl = new URL("https://s3.amazonaws.com/test-bucket/products/1/thumbnail.png");
+
+        S3Utilities mockS3Utilities = mock(S3Utilities.class);
+        when(s3Client.utilities()).thenReturn(mockS3Utilities);
+        when(mockS3Utilities.getUrl(any(GetUrlRequest.class))).thenReturn(mockUrl);
+
+        // When
+        String imageUrl = productImageUploadService.registerProductImage(request);
+
+        // Then
+        assertThat(imageUrl).contains("products/1/thumbnail.png");
+
+        // S3 업로드가 정상적으로 호출되었는지 검증
+        verify(s3Client, times(1)).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    }
+
+}

--- a/src/test/java/org/orderhub/pr/product/service/listener/ProductEventListenerTest.java
+++ b/src/test/java/org/orderhub/pr/product/service/listener/ProductEventListenerTest.java
@@ -1,0 +1,83 @@
+package org.orderhub.pr.product.service.listener;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.orderhub.pr.product.domain.event.ProductCreatedEvent;
+import org.orderhub.pr.product.dto.request.ProductImageRegisterRequest;
+import org.orderhub.pr.product.service.ProductImageService;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ProductEventListenerTest {
+
+    private ProductEventListener productEventListener;
+
+    @Mock
+    private ProductImageService productImageService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        productEventListener = new ProductEventListener(productImageService);
+    }
+
+    @Test
+    @DisplayName("상품 생성 이벤트가 발생했을 때 이미지 처리가 정상적으로 실행되는지 검증")
+    void shouldProcessProductImageOnProductCreatedEvent() throws IOException {
+        // Given
+        ProductImageRegisterRequest imageRequest = ProductImageRegisterRequest.builder()
+                .productId(1L)
+                .image(null)
+                .build();
+
+        ProductCreatedEvent event = ProductCreatedEvent.builder()
+                .imageRequest(imageRequest)
+                .build();
+
+        // When
+        productEventListener.handleProductCreated(event);
+
+        // Then
+        ArgumentCaptor<ProductImageRegisterRequest> captor = ArgumentCaptor.forClass(ProductImageRegisterRequest.class);
+        verify(productImageService, times(1)).processProductImage(captor.capture());
+
+        ProductImageRegisterRequest capturedRequest = captor.getValue();
+        assertThat(capturedRequest.getProductId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("예외 발생 시 정상적으로 처리되는지 검증")
+    void shouldHandleExceptionWhenProcessingImageFails() throws IOException {
+        // Given
+        ProductImageRegisterRequest imageRequest = ProductImageRegisterRequest.builder()
+                .productId(2L)
+                .image(null)
+                .build();
+
+        ProductCreatedEvent event = ProductCreatedEvent.builder()
+                .imageRequest(imageRequest)
+                .build();
+
+        doThrow(new IOException("S3 Upload Failed")).when(productImageService).processProductImage(imageRequest);
+
+        // When & Then
+        assertThatThrownBy(() -> productEventListener.handleProductCreated(event))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("S3 Upload Failed");
+
+        verify(productImageService, times(1)).processProductImage(imageRequest);
+    }
+
+}


### PR DESCRIPTION
### 카테고리 기능 개발
- 카테고리 등록
  - 카테고리 분류 : 대분류, 중분류, 소분류
  - 하나의 `category` 도메인에서 관리, 트리 구조
  - 카테고리 등록시 자기 자신을 자식이나 부모 카테고리로 등록하지 않도록 예외 처리
  - 카테고리 상태로 논리 삭제 지원
  - 관리자가 카테고리를 등록할 수 있게 비지니스 로직 작성
  - 카테고리 등록 테스트 작성
- 카테고리 수정
  - 카테고리 계층(부모 id) 변경 가능
  - 카테고리 이름 수정 가능
  - 카테고리 수정시 자기 자신을 자식이나 부모 카테고리로 등록하지 않도록 예외 처리
  - 더티 체킹 활용
  - 카테고리 수정 테스트 작성
- 카테고리 삭제
  - 논리 삭제 지원
  - 복구 기능 지원
  - 카테고리 삭제 테스트 작성
- 카테고리 조회
  - 관리자가 사용할 모든 카테고리(논리 삭제된 카테고리) 조회 기능
  - 매니저가 사용할 사용 가능한 카테고리 조회 기능
  - 재귀적 tree 구조 지원
  - 카테고리 조회 테스트 작성
  
### 상품 기능 개발
 - 상품 등록
   - 상품 서비스, 상품 이미지 서비스 분리 -> 도메인 이벤트 패턴 사용(비동기 처리)
   - 상품 등록 -> 이벤트 발행 -> 이미지 등록(S3) -> 이미지 정보 등록
   - 이미지 예외처리(파일 제한, 지원하지 않는 확장자, 파일 형식) -> aop 사용
   - S3 테스트 코드 작성
   - 이미지 등록 테스트 코드 작성
   - 이벤트 리스너 및 발행 테스트 코드 작성
   - 상품 등록 테스트 코드 작성
- 상품 수정
  - 상품 수정(PUT, 전체 데이터 수정) 가능
  - 상품 이미지 수정 가능
  - 상품 수정 테스트 작성
  - 상품 이미지 수정 테스트 작성
- 상품 삭제
  - 논리 삭제
  - 상품 삭제 테스트 작성
- 상품 조회
  - delete 되지 않은 요소 조회 (매니저 이하)
  - delete 된 요소 조회 (관리자 이상)
  - delete 되지 않은 요소 필터로 조회 가능
  - 상품 조회 테스트 코드 작성