### PR TITLE
feat: 이미지 생성 이벤트 수정, 제품 업데이트시 이벤트 발행

### DIFF
--- a/src/main/java/org/orderhub/pr/product/aop/ImageValidationAspect.java
+++ b/src/main/java/org/orderhub/pr/product/aop/ImageValidationAspect.java
@@ -5,6 +5,7 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.orderhub.pr.system.config.ImageConfig;
+import org.orderhub.pr.util.dto.InMemoryFile;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -28,7 +29,7 @@ public class ImageValidationAspect {
         Set<String> validExtensions = imageConfig.getSupportedExtensionsSet();
 
         Arrays.stream(args).forEach(arg -> {
-            if (arg instanceof MultipartFile file) {
+            if (arg instanceof InMemoryFile file) {
                 validateFileSize(file);
                 validateFileExtension(file, validExtensions);
             }
@@ -36,13 +37,13 @@ public class ImageValidationAspect {
         return joinPoint.proceed(args);
     }
 
-    private void validateFileSize(MultipartFile file) {
+    private void validateFileSize(InMemoryFile file) {
         if (file.getSize() > imageConfig.getMaxFileSize()) {
             throw new IllegalArgumentException(FILE_SIZE_EXCEEDED);
         }
     }
 
-    private void validateFileExtension(MultipartFile file, Set<String> validExtensions) {
+    private void validateFileExtension(InMemoryFile file, Set<String> validExtensions) {
         String originalFilename = file.getOriginalFilename();
         if (originalFilename == null || !originalFilename.contains(".")) {
             throw new IllegalArgumentException(INVALID_FILE_FORMAT);

--- a/src/main/java/org/orderhub/pr/product/dto/request/ProductImageRegisterRequest.java
+++ b/src/main/java/org/orderhub/pr/product/dto/request/ProductImageRegisterRequest.java
@@ -12,5 +12,5 @@ import org.springframework.web.multipart.MultipartFile;
 @NoArgsConstructor
 public class ProductImageRegisterRequest {
     private Long productId;
-    private MultipartFile image;
+    private String storedFileKey;
 }

--- a/src/main/java/org/orderhub/pr/product/dto/request/ProductImageRegisterRequest.java
+++ b/src/main/java/org/orderhub/pr/product/dto/request/ProductImageRegisterRequest.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.orderhub.pr.util.dto.InMemoryFile;
 import org.springframework.web.multipart.MultipartFile;
 
 @Data
@@ -12,5 +13,5 @@ import org.springframework.web.multipart.MultipartFile;
 @NoArgsConstructor
 public class ProductImageRegisterRequest {
     private Long productId;
-    private String storedFileKey;
+    private InMemoryFile storedFile;
 }

--- a/src/main/java/org/orderhub/pr/product/dto/request/ProductImageUpdateRequest.java
+++ b/src/main/java/org/orderhub/pr/product/dto/request/ProductImageUpdateRequest.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.orderhub.pr.util.dto.InMemoryFile;
 import org.springframework.web.multipart.MultipartFile;
 
 @Data
@@ -12,5 +13,5 @@ import org.springframework.web.multipart.MultipartFile;
 @NoArgsConstructor
 public class ProductImageUpdateRequest {
     private Long productId;
-    private MultipartFile image;
+    private InMemoryFile storedFile;
 }

--- a/src/main/java/org/orderhub/pr/product/service/impl/S3ProductImageServiceImpl.java
+++ b/src/main/java/org/orderhub/pr/product/service/impl/S3ProductImageServiceImpl.java
@@ -5,6 +5,7 @@ import org.orderhub.pr.product.aop.annotation.ValidateImage;
 import org.orderhub.pr.product.dto.request.ProductImageRegisterRequest;
 import org.orderhub.pr.product.dto.request.ProductImageUpdateRequest;
 import org.orderhub.pr.product.service.ProductImageUploadService;
+import org.orderhub.pr.util.service.InMemoryFileStorage;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -19,6 +20,8 @@ import java.net.URL;
 @Service
 @RequiredArgsConstructor
 public class S3ProductImageServiceImpl implements ProductImageUploadService {
+
+    private final InMemoryFileStorage inMemoryFileStorage;
 
     @Value("${aws.s3.bucket-name}")
     private String bucketName;
@@ -60,7 +63,7 @@ public class S3ProductImageServiceImpl implements ProductImageUploadService {
         return fileUrl.toExternalForm();
     }
 
-    private String getFileExtension(MultipartFile file) {
+    private String getFileExtension(Long productId, MultipartFile file) {
         String originalFilename = file.getOriginalFilename();
         return originalFilename.substring(originalFilename.lastIndexOf(".") + 1).toLowerCase();
     }

--- a/src/main/java/org/orderhub/pr/product/service/impl/S3ProductImageServiceImpl.java
+++ b/src/main/java/org/orderhub/pr/product/service/impl/S3ProductImageServiceImpl.java
@@ -5,6 +5,7 @@ import org.orderhub.pr.product.aop.annotation.ValidateImage;
 import org.orderhub.pr.product.dto.request.ProductImageRegisterRequest;
 import org.orderhub.pr.product.dto.request.ProductImageUpdateRequest;
 import org.orderhub.pr.product.service.ProductImageUploadService;
+import org.orderhub.pr.util.dto.InMemoryFile;
 import org.orderhub.pr.util.service.InMemoryFileStorage;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -21,8 +22,6 @@ import java.net.URL;
 @RequiredArgsConstructor
 public class S3ProductImageServiceImpl implements ProductImageUploadService {
 
-    private final InMemoryFileStorage inMemoryFileStorage;
-
     @Value("${aws.s3.bucket-name}")
     private String bucketName;
 
@@ -30,28 +29,28 @@ public class S3ProductImageServiceImpl implements ProductImageUploadService {
 
     @ValidateImage
     public String registerProductImage(ProductImageRegisterRequest productImageRegisterRequest) throws IOException {
-        String fileKey = generateFileKey(productImageRegisterRequest.getProductId(), productImageRegisterRequest.getImage());
-        return uploadToS3(productImageRegisterRequest.getImage(), fileKey);
+        String fileKey = generateFileKey(productImageRegisterRequest.getProductId(), productImageRegisterRequest.getStoredFile());
+        return uploadToS3(productImageRegisterRequest.getStoredFile(), fileKey);
     }
 
     @ValidateImage
     public String updateProductImage(ProductImageUpdateRequest productImageUpdateRequest) throws IOException {
-        String fileKey = generateFileKey(productImageUpdateRequest.getProductId(), productImageUpdateRequest.getImage());
-        return uploadToS3(productImageUpdateRequest.getImage(), fileKey);
+        String fileKey = generateFileKey(productImageUpdateRequest.getProductId(), productImageUpdateRequest.getStoredFile());
+        return uploadToS3(productImageUpdateRequest.getStoredFile(), fileKey);
     }
 
-    private String generateFileKey(Long productId, MultipartFile file) {
-        return "products/" + productId + "/thumbnail." + getFileExtension(file);
+    private String generateFileKey(Long productId, InMemoryFile file) {
+        return "products/" + productId + "/thumbnail." + getFileExtension(file.getOriginalFilename());
     }
 
-    private String uploadToS3(MultipartFile file, String fileKey) throws IOException {
+    private String uploadToS3(InMemoryFile file, String fileKey) throws IOException {
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(bucketName)
                 .key(fileKey)
                 .contentType(file.getContentType())
                 .build();
         s3Client.putObject(putObjectRequest,
-                software.amazon.awssdk.core.sync.RequestBody.fromBytes(file.getBytes()));
+                software.amazon.awssdk.core.sync.RequestBody.fromBytes(file.getContent()));
         S3Utilities s3Utilities = s3Client.utilities();
 
         GetUrlRequest getUrlRequest = GetUrlRequest.builder()
@@ -63,8 +62,7 @@ public class S3ProductImageServiceImpl implements ProductImageUploadService {
         return fileUrl.toExternalForm();
     }
 
-    private String getFileExtension(Long productId, MultipartFile file) {
-        String originalFilename = file.getOriginalFilename();
-        return originalFilename.substring(originalFilename.lastIndexOf(".") + 1).toLowerCase();
+    private String getFileExtension(String originalFileName) {
+        return originalFileName.substring(originalFileName.lastIndexOf(".") + 1).toLowerCase();
     }
 }

--- a/src/main/java/org/orderhub/pr/util/dto/InMemoryFile.java
+++ b/src/main/java/org/orderhub/pr/util/dto/InMemoryFile.java
@@ -1,0 +1,16 @@
+package org.orderhub.pr.util.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class InMemoryFile {
+    private String originalFilename;
+    private String contentType;
+    private byte[] content;
+}

--- a/src/main/java/org/orderhub/pr/util/dto/InMemoryFile.java
+++ b/src/main/java/org/orderhub/pr/util/dto/InMemoryFile.java
@@ -13,4 +13,8 @@ public class InMemoryFile {
     private String originalFilename;
     private String contentType;
     private byte[] content;
+
+    public int getSize() {
+        return content.length;
+    }
 }

--- a/src/main/java/org/orderhub/pr/util/service/InMemoryFileStorage.java
+++ b/src/main/java/org/orderhub/pr/util/service/InMemoryFileStorage.java
@@ -1,0 +1,9 @@
+package org.orderhub.pr.util.service;
+
+import org.orderhub.pr.util.dto.InMemoryFile;
+
+public interface InMemoryFileStorage {
+    void put(String key, InMemoryFile file);
+    InMemoryFile get(String key);
+    void remove(String key);
+}

--- a/src/main/java/org/orderhub/pr/util/service/impl/InMemoryFileStorageImpl.java
+++ b/src/main/java/org/orderhub/pr/util/service/impl/InMemoryFileStorageImpl.java
@@ -1,0 +1,29 @@
+package org.orderhub.pr.util.service.impl;
+
+import org.orderhub.pr.util.dto.InMemoryFile;
+import org.orderhub.pr.util.service.InMemoryFileStorage;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class InMemoryFileStorageImpl implements InMemoryFileStorage {
+    private final Map<String, InMemoryFile> storage = new ConcurrentHashMap<>();
+
+    @Override
+    public void put(String key, InMemoryFile file) {
+        storage.put(key, file);
+    }
+
+    @Override
+    public InMemoryFile get(String key) {
+        return storage.get(key);
+    }
+
+    @Override
+    public void remove(String key) {
+        storage.remove(key);
+    }
+}

--- a/src/test/java/org/orderhub/pr/product/aop/ImageValidationAspectTest.java
+++ b/src/test/java/org/orderhub/pr/product/aop/ImageValidationAspectTest.java
@@ -5,9 +5,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.orderhub.pr.system.config.ImageConfig;
 import org.orderhub.pr.product.exception.ExceptionMessage;
-import org.springframework.web.multipart.MultipartFile;
+import org.orderhub.pr.system.config.ImageConfig;
+import org.orderhub.pr.util.dto.InMemoryFile;
 
 import java.util.Set;
 
@@ -19,20 +19,14 @@ class ImageValidationAspectTest {
     private ImageValidationAspect imageValidationAspect;
     private ImageConfig imageConfig;
     private ProceedingJoinPoint proceedingJoinPoint;
-    private MultipartFile mockFile;
 
     @BeforeEach
     void setUp() {
-        // ImageConfig 모킹
         imageConfig = mock(ImageConfig.class);
         when(imageConfig.getMaxFileSize()).thenReturn(5_242_880L); // 5MB
         when(imageConfig.getSupportedExtensionsSet()).thenReturn(Set.of("jpg", "jpeg", "png", "webp"));
 
-        // AOP 인스턴스 생성
         imageValidationAspect = new ImageValidationAspect(imageConfig);
-
-        // Mock 파일 생성
-        mockFile = mock(MultipartFile.class);
         proceedingJoinPoint = mock(ProceedingJoinPoint.class);
     }
 
@@ -40,13 +34,19 @@ class ImageValidationAspectTest {
     @DisplayName("파일 크기가 허용 범위 내일 때 정상 동작")
     void shouldAllowValidFileSize() throws Throwable {
         // Given
-        when(mockFile.getSize()).thenReturn(1_000_000L); // 1MB
-        when(mockFile.getOriginalFilename()).thenReturn("test.jpg");
-        Object[] args = {mockFile};
+        InMemoryFile inMemoryFile = InMemoryFile.builder()
+                .originalFilename("test.jpg")
+                .contentType("image/jpeg")
+                .content(new byte[1_000_000]) // 1MB
+                .build();
+
+        Object[] args = {inMemoryFile};
         when(proceedingJoinPoint.getArgs()).thenReturn(args);
 
-        // When & Then
+        // When
         imageValidationAspect.validateImageSize(proceedingJoinPoint);
+
+        // Then
         verify(proceedingJoinPoint, times(1)).proceed(args);
     }
 
@@ -54,9 +54,13 @@ class ImageValidationAspectTest {
     @DisplayName("파일 크기가 초과될 경우 예외 발생")
     void shouldThrowExceptionWhenFileSizeExceedsLimit() {
         // Given
-        when(mockFile.getSize()).thenReturn(10_000_000L); // 10MB
-        when(mockFile.getOriginalFilename()).thenReturn("test.jpg");
-        Object[] args = {mockFile};
+        InMemoryFile inMemoryFile = InMemoryFile.builder()
+                .originalFilename("large.jpg")
+                .contentType("image/jpeg")
+                .content(new byte[10_000_000]) // 10MB
+                .build();
+
+        Object[] args = {inMemoryFile};
         when(proceedingJoinPoint.getArgs()).thenReturn(args);
 
         // When & Then
@@ -69,13 +73,19 @@ class ImageValidationAspectTest {
     @DisplayName("파일 확장자가 허용된 경우 정상 동작")
     void shouldAllowValidFileExtension() throws Throwable {
         // Given
-        when(mockFile.getSize()).thenReturn(1_000_000L); // 1MB
-        when(mockFile.getOriginalFilename()).thenReturn("test.png");
-        Object[] args = {mockFile};
+        InMemoryFile inMemoryFile = InMemoryFile.builder()
+                .originalFilename("test.png")
+                .contentType("image/png")
+                .content(new byte[500_000])
+                .build();
+
+        Object[] args = {inMemoryFile};
         when(proceedingJoinPoint.getArgs()).thenReturn(args);
 
-        // When & Then
+        // When
         imageValidationAspect.validateImageSize(proceedingJoinPoint);
+
+        // Then
         verify(proceedingJoinPoint, times(1)).proceed(args);
     }
 
@@ -83,9 +93,13 @@ class ImageValidationAspectTest {
     @DisplayName("파일 확장자가 허용되지 않은 경우 예외 발생")
     void shouldThrowExceptionWhenFileExtensionIsNotAllowed() {
         // Given
-        when(mockFile.getSize()).thenReturn(1_000_000L); // 1MB
-        when(mockFile.getOriginalFilename()).thenReturn("test.txt");
-        Object[] args = {mockFile};
+        InMemoryFile inMemoryFile = InMemoryFile.builder()
+                .originalFilename("test.txt")
+                .contentType("text/plain")
+                .content(new byte[100_000])
+                .build();
+
+        Object[] args = {inMemoryFile};
         when(proceedingJoinPoint.getArgs()).thenReturn(args);
 
         // When & Then
@@ -98,9 +112,13 @@ class ImageValidationAspectTest {
     @DisplayName("파일 이름이 없는 경우 예외 발생")
     void shouldThrowExceptionWhenFileNameIsNull() {
         // Given
-        when(mockFile.getSize()).thenReturn(1_000_000L); // 1MB
-        when(mockFile.getOriginalFilename()).thenReturn(null);
-        Object[] args = {mockFile};
+        InMemoryFile inMemoryFile = InMemoryFile.builder()
+                .originalFilename(null)
+                .contentType("image/jpeg")
+                .content(new byte[100_000])
+                .build();
+
+        Object[] args = {inMemoryFile};
         when(proceedingJoinPoint.getArgs()).thenReturn(args);
 
         // When & Then
@@ -113,9 +131,13 @@ class ImageValidationAspectTest {
     @DisplayName("파일 이름에 확장자가 없는 경우 예외 발생")
     void shouldThrowExceptionWhenFileNameHasNoExtension() {
         // Given
-        when(mockFile.getSize()).thenReturn(1_000_000L); // 1MB
-        when(mockFile.getOriginalFilename()).thenReturn("testfile");
-        Object[] args = {mockFile};
+        InMemoryFile inMemoryFile = InMemoryFile.builder()
+                .originalFilename("testfile") // 확장자 없음
+                .contentType("image/jpeg")
+                .content(new byte[100_000])
+                .build();
+
+        Object[] args = {inMemoryFile};
         when(proceedingJoinPoint.getArgs()).thenReturn(args);
 
         // When & Then
@@ -123,5 +145,4 @@ class ImageValidationAspectTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(ExceptionMessage.INVALID_FILE_FORMAT);
     }
-
 }

--- a/src/test/java/org/orderhub/pr/product/service/impl/ProductImageServiceImplCreateTest.java
+++ b/src/test/java/org/orderhub/pr/product/service/impl/ProductImageServiceImplCreateTest.java
@@ -12,6 +12,7 @@ import org.orderhub.pr.product.dto.request.ProductImageRegisterRequest;
 import org.orderhub.pr.product.repository.ProductRepository;
 import org.orderhub.pr.product.service.ProductImageService;
 import org.orderhub.pr.product.service.ProductImageUploadService;
+import org.orderhub.pr.util.dto.InMemoryFile;  // InMemoryFile 임포트
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -43,13 +44,15 @@ class ProductImageServiceImplCreateTest {
     void shouldProcessProductImageSuccessfully() throws IOException {
         // Given
         Long productId = 1L;
-        MultipartFile mockFile = mock(MultipartFile.class);
-        when(mockFile.getOriginalFilename()).thenReturn("test.jpg");
-        when(mockFile.getBytes()).thenReturn("image content".getBytes());
+        InMemoryFile inMemoryFile = InMemoryFile.builder()
+                .originalFilename("test.jpg")
+                .contentType("image/jpeg")
+                .content("image content".getBytes())
+                .build();
 
         ProductImageRegisterRequest request = ProductImageRegisterRequest.builder()
                 .productId(productId)
-                .image(mockFile)
+                .storedFile(inMemoryFile)
                 .build();
 
         String mockImageUrl = "https://s3.amazonaws.com/test-bucket/products/1/thumbnail.jpg";
@@ -72,12 +75,15 @@ class ProductImageServiceImplCreateTest {
     void shouldThrowExceptionWhenProductNotFound() throws IOException {
         // Given
         Long nonExistentProductId = 999L;
-        MultipartFile mockFile = mock(MultipartFile.class);
-        when(mockFile.getOriginalFilename()).thenReturn("test.jpg");
+        InMemoryFile inMemoryFile = InMemoryFile.builder()
+                .originalFilename("test.jpg")
+                .contentType("image/jpeg")
+                .content("image content".getBytes())
+                .build();
 
         ProductImageRegisterRequest request = ProductImageRegisterRequest.builder()
                 .productId(nonExistentProductId)
-                .image(mockFile)
+                .storedFile(inMemoryFile)
                 .build();
 
         when(productRepository.findById(nonExistentProductId)).thenReturn(Optional.empty());
@@ -96,13 +102,15 @@ class ProductImageServiceImplCreateTest {
     void shouldUpdateProductImageCorrectly() throws IOException {
         // Given
         Long productId = 2L;
-        MultipartFile mockFile = mock(MultipartFile.class);
-        when(mockFile.getOriginalFilename()).thenReturn("image.png");
-        when(mockFile.getBytes()).thenReturn("image content".getBytes());
+        InMemoryFile inMemoryFile = InMemoryFile.builder()
+                .originalFilename("image.png")
+                .contentType("image/png")
+                .content("image content".getBytes())
+                .build();
 
         ProductImageRegisterRequest request = ProductImageRegisterRequest.builder()
                 .productId(productId)
-                .image(mockFile)
+                .storedFile(inMemoryFile)
                 .build();
 
         String mockImageUrl = "https://s3.amazonaws.com/test-bucket/products/2/thumbnail.png";

--- a/src/test/java/org/orderhub/pr/product/service/impl/ProductServiceImplCreateTest.java
+++ b/src/test/java/org/orderhub/pr/product/service/impl/ProductServiceImplCreateTest.java
@@ -44,13 +44,10 @@ class ProductServiceImplCreateTest {
     @Mock
     private ApplicationEventPublisher eventPublisher;
 
-    @Mock
-    private ProductImageService productImageService;
-
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        productService = new ProductServiceImpl(productRepository, customProductRepository, eventPublisher, categoryService, productImageService);
+        productService = new ProductServiceImpl(productRepository, customProductRepository, eventPublisher, categoryService);
     }
 
 //    @Test

--- a/src/test/java/org/orderhub/pr/product/service/impl/ProductServiceImplUpdateTest.java
+++ b/src/test/java/org/orderhub/pr/product/service/impl/ProductServiceImplUpdateTest.java
@@ -42,14 +42,11 @@ class ProductServiceImplUpdateTest {
     @Mock
     private ApplicationEventPublisher eventPublisher;
 
-    @Mock
-    private ProductImageService productImageService;
-
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        productService = new ProductServiceImpl(productRepository, customProductRepository, eventPublisher, categoryService, productImageService);
+        productService = new ProductServiceImpl(productRepository, customProductRepository, eventPublisher, categoryService);
     }
 
     @Test


### PR DESCRIPTION
## 이미지 생성 이벤트 수정
- 제품 생성시 이미지가 비동기로 업데이트 되도록 수정
- 이미지 파일이 소모되지 않도록 메모리에서 보유하다 저장하도록 개선
## 제품 업데이트시 이벤트 발행
- store microservice에서 보유중인 정보(제품 이름, 가격)에 수정이 생겼을 경우 이벤트 발행하여 데이터 정합성을 지키도록 함
- kafka로 이벤트 produce
  - kafka 설정
  - producer 및 이벤트, 관련 dto 추가